### PR TITLE
GitHub Actions to run example routers

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,0 +1,73 @@
+# Copyright (C) 2023, Advanced Micro Devices, Inc.  All rights reserved.
+#
+# Author: Eddie Hung, AMD
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: make
+on:
+  push:
+  pull_request:
+jobs:
+  make:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        router:
+          - rwroute
+          - nxroute-poc
+        benchmark:
+          - boom_soc
+          - ispd16_example2
+          - koios_dla_like_large
+          - rosetta_fd
+          - vtr_mcml
+        exclude:
+          # Insufficient memory on GitHub Actions
+          - router: rwroute
+            benchmark: boom_soc
+          - router: rwroute
+            benchmark: ispd16_example2
+          - router: rwroute
+            benchmark: koios_dla_like_large
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+      - if: matrix.router == 'nxroute-poc'
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - if: matrix.router == 'nxroute-poc'
+        run:
+           wget -q https://github.com/eddieh-xlnx/fpga24_routing_contest/releases/download/xvu3p/xcvu3p.device
+      - run:
+          make ROUTER="${{ matrix.router }}" BENCHMARKS="${{ matrix.benchmark }}" VERBOSE=1
+      - run:
+          make ROUTER="${{ matrix.router }}" BENCHMARKS="${{ matrix.benchmark }}" VERBOSE=1
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Logs
+          path: |
+           *.log
+           *.check
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: ${{ matrix.router }}-${{ matrix.benchmark }}
+          path: |
+           *.dcp
+           *.phys
+           ${{ matrix.benchmark }}.netlist.edn/*
+           *_load.tcl
+           !*_unrouted.phys

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ fpga-interchange-schema/interchange/capnp/java.capnp:
 # When inside GitHub Actions (which has no access to Vivado), and also when the routed netlist
 # was successfully converted back into a DCP, then return a mock PASS result
 %_$(ROUTER).check: %.netlist %_$(ROUTER).phys | compile-java
-	if ./gradlew -Dorg.gradle.jvmargs="-Xms6g -Xmx6g" -Dmain=com.xilinx.fpga24_routing_contest.CheckPhysNetlist :run --args='$^' $(call log_and_or_display,$@.log); then \
+	if ./gradlew -DjvmArgs="-Xms6g -Xmx6g" -Dmain=com.xilinx.fpga24_routing_contest.CheckPhysNetlist :run --args='$^' $(call log_and_or_display,$@.log); then \
             echo "PASS" > $@; \
         elif [[ ! -z "$(GITHUB_ACTION)" && -f "$(patsubst %.check,%.dcp,$@)" ]]; then \
             echo "PASS" > $@; \

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,23 @@ ROUTER ?= rwroute
 # Make /usr/bin/time only print out wall-clock time in seconds
 export TIME=Wall-clock time (sec): %e
 
+# Existence of the VERBOSE environment variable indicates whether router/
+# checker outputs will be displayed on screen
+ifdef VERBOSE
+    log_and_or_display = 2>&1 | tee $(1)
+else
+    log_and_or_display = > $(1) 2>&1
+endif
+
+ifdef GITHUB_ACTIONS
+    # Limit Java heap size inside GitHub Actions to 6G
+    JVM_HEAP = -Xms6g -Xmx6g
+else
+    # If not specified, limit Java heap size ~32G
+    JVM_HEAP ?= -Xmx32736m -Xmx32736m
+endif
+
+
 # Default recipe: route and score all given download-benchmarks
 .PHONY: run-$(ROUTER)
 run-$(ROUTER): score-$(ROUTER)
@@ -38,7 +55,7 @@ nxroute-deps:
 # Download and unpack all benchmarks
 .PHONY: download-benchmarks
 download-benchmarks:
-	curl -L $(BENCHMARKS_URL) | tar -xzv
+	curl -L $(BENCHMARKS_URL) | tar -xz
 
 .PRECIOUS: %_unrouted.phys %.netlist
 %_unrouted.phys %.netlist:
@@ -51,10 +68,18 @@ fpga-interchange-schema/interchange/capnp/java.capnp:
 	wget https://raw.githubusercontent.com/capnproto/capnproto-java/master/compiler/src/main/schema/capnp/java.capnp -O $@
 
 # Gradle is used to invoke the CheckPhysNetlist class' main method with arguments
-# $^ (%.netlist and %_rwroute.phys), and redirecting all output to $@.log (%_rwroute.check.log).
+# $^ (%.netlist and %_rwroute.phys), and log_and_or_displaying all output to $@.log (%_rwroute.check.log).
 # The exit code of Gradle determines if 'PASS' or 'FAIL' is written to $@ (%_rwroute.check)
+# When inside GitHub Actions (which has no access to Vivado), and also when the routed netlist
+# was successfully converted back into a DCP, then return a mock PASS result
 %_$(ROUTER).check: %.netlist %_$(ROUTER).phys | compile-java
-	( ( ./gradlew -Dmain=com.xilinx.fpga24_routing_contest.CheckPhysNetlist :run --args='$^' &> $@.log && echo "PASS" ) || echo "FAIL") > $@
+	if ./gradlew -Dorg.gradle.jvmargs="-Xms6g -Xmx6g" -Dmain=com.xilinx.fpga24_routing_contest.CheckPhysNetlist :run --args='$^' $(call log_and_or_display,$@.log); then \
+            echo "PASS" > $@; \
+        elif [[ ! -z "$(GITHUB_ACTION)" && -f "$(patsubst %.check,%.dcp,$@)" ]]; then \
+            echo "PASS" > $@; \
+        else \
+            echo "FAIL" > $@; \
+        fi
 
 .PHONY: score-$(ROUTER)
 score-$(ROUTER): $(addsuffix _$(ROUTER).check, $(BENCHMARKS))
@@ -74,20 +99,19 @@ distclean: clean
 #### BEGIN ROUTER RECIPES
 
 ## RWROUTE
-# _JAVA_OPTIONS="-Xms32736m -Xmx32736m" sets the initial and maximum heap size of the JVM to be ~32GB
 # /usr/bin/time is used to measure the wall clock time
 # Gradle is used to invoke the PartialRouterPhysNetlist class' main method with arguments
-# $< (%_unrouted.phys) and $@ (%_rwroute.phys), and redirecting all output into %_rwroute.phys.log
+# $< (%_unrouted.phys) and $@ (%_rwroute.phys), and log_and_or_displaying all output into %_rwroute.phys.log
 %_rwroute.phys: %_unrouted.phys | compile-java
-	_JAVA_OPTIONS="-Xms32736m -Xmx32736m" /usr/bin/time ./gradlew -Dmain=com.xilinx.fpga24_routing_contest.PartialRouterPhysNetlist :run --args='$< $@' &> $@.log
+	(/usr/bin/time ./gradlew -DjvmArgs="$(JVM_HEAP)" -Dmain=com.xilinx.fpga24_routing_contest.PartialRouterPhysNetlist :run --args='$< $@') $(call log_and_or_display,$@.log)
 
 ## NXROUTE-POC
 %_nxroute-poc.phys: %_unrouted.phys xcvu3p.device | nxroute-deps fpga-interchange-schema/interchange/capnp/java.capnp
-	/usr/bin/time python3 networkx-proof-of-concept-router/nxroute-poc.py $< $@ &> $@.log
+	(/usr/bin/time python3 networkx-proof-of-concept-router/nxroute-poc.py $< $@) $(call log_and_or_display,$@.log)
 
 ## EXAMPLEROUTE
 # %_exampleroute.phys: %_unrouted.phys | fpga-interchange-schema/interchange/capnp/java.capnp
-# 	/usr/bin/time <custom router here> $< $@ &> $@.log
+# 	(/usr/bin/time <custom router here> $< $@) > $@.log $(call log_and_or_display,$@.log)
 
 #### END ROUTER RECIPES
 

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ fpga-interchange-schema/interchange/capnp/java.capnp:
 	wget https://raw.githubusercontent.com/capnproto/capnproto-java/master/compiler/src/main/schema/capnp/java.capnp -O $@
 
 # Gradle is used to invoke the CheckPhysNetlist class' main method with arguments
-# $^ (%.netlist and %_rwroute.phys), and log_and_or_displaying all output to $@.log (%_rwroute.check.log).
+# $^ (%.netlist and %_rwroute.phys), and display/redirect all output to $@.log (%_rwroute.check.log).
 # The exit code of Gradle determines if 'PASS' or 'FAIL' is written to $@ (%_rwroute.check)
 # When inside GitHub Actions (which has no access to Vivado), and also when the routed netlist
 # was successfully converted back into a DCP, then return a mock PASS result
@@ -101,7 +101,7 @@ distclean: clean
 ## RWROUTE
 # /usr/bin/time is used to measure the wall clock time
 # Gradle is used to invoke the PartialRouterPhysNetlist class' main method with arguments
-# $< (%_unrouted.phys) and $@ (%_rwroute.phys), and log_and_or_displaying all output into %_rwroute.phys.log
+# $< (%_unrouted.phys) and $@ (%_rwroute.phys), and display/redirect all output into %_rwroute.phys.log
 %_rwroute.phys: %_unrouted.phys | compile-java
 	(/usr/bin/time ./gradlew -DjvmArgs="$(JVM_HEAP)" -Dmain=com.xilinx.fpga24_routing_contest.PartialRouterPhysNetlist :run --args='$< $@') $(call log_and_or_display,$@.log)
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,10 @@ sourceSets {
 }
 
 task run(type: JavaExec) {
-   classpath = sourceSets.main.runtimeClasspath 
-   main = System.getProperty('main')
-   jvmArgs System.getProperty('jvmArgs', '').split(' ')
+    classpath = sourceSets.main.runtimeClasspath
+    main = System.getProperty('main')
+    if (System.getProperty('jvmArgs') != null) {
+        jvmArgs System.getProperty('jvmArgs').split(' ')
+    }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,5 +32,6 @@ sourceSets {
 task run(type: JavaExec) {
    classpath = sourceSets.main.runtimeClasspath 
    main = System.getProperty('main')
+   jvmArgs System.getProperty('jvmArgs', '').split(' ')
 }
 

--- a/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java
+++ b/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java
@@ -63,6 +63,11 @@ public class CheckPhysNetlist {
         Path outputDcp = Paths.get(FileTools.removeFileExtension(args[1]) + ".dcp");
         design.writeCheckpoint(outputDcp);
 
+        if (!FileTools.isVivadoOnPath()) {
+            System.err.println("ERROR: `vivado` not detected on $PATH");
+            System.exit(1);
+        }
+
         // Call Vivado's `report_route_status` command on this DCP
         List<String> encryptedCells = netlist.getEncryptedCells();
         boolean encrypted = encryptedCells != null && !encryptedCells.isEmpty();


### PR DESCRIPTION
1. Since GitHub Actions has no access to Vivado, currently the `report_route_status` functionality always returns a mock PASS status.
2. Due to GitHub Actions memory limitations (7GB RAM), `rwroute` can only tackle the two smallest benchmarks.
3. Since `nxroute-poc` only operates on one clock region of the device, it can partially route all five benchmarks.
4. The resulting log/physical netlist/DCPs of all 2 (`rwroute`) + 5 (`nxroute`) runs are uploaded as artifacts for 90 days.