### PR TITLE
Fix typo Xmx -> Xms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ifdef GITHUB_ACTIONS
     JVM_HEAP = -Xms6g -Xmx6g
 else
     # If not specified, limit Java heap size ~32G
-    JVM_HEAP ?= -Xmx32736m -Xmx32736m
+    JVM_HEAP ?= -Xms32736m -Xmx32736m
 endif
 
 


### PR DESCRIPTION
Java's initial heap size to be the same as maximum heap size (just shy of 32GB) to minimize reallocations.