### PR TITLE
Add ability to execute report_route_status on remote server

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -47,13 +47,31 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-      - if: matrix.router == 'nxroute-poc'
+      - name: Download xcvu3p.device (nxroute-poc only)
+        if: matrix.router == 'nxroute-poc'
         run:
            wget -q https://github.com/eddieh-xlnx/fpga24_routing_contest/releases/download/xvu3p/xcvu3p.device
-      - run:
+      - env:
+          REPORT_ROUTE_STATUS_URL:      ${{ secrets.REPORT_ROUTE_STATUS_URL }}
+          REPORT_ROUTE_STATUS_AUTH:     ${{ secrets.REPORT_ROUTE_STATUS_AUTH }}
+          CHECK_PHYS_NETLIST_MOCK_PASS: ${{ matrix.router != 'nxroute-poc' && secrets.REPORT_ROUTE_STATUS_URL == '' }}
+        run: |
           make ROUTER="${{ matrix.router }}" BENCHMARKS="${{ matrix.benchmark }}" VERBOSE=1
-      - run:
+      - name: Score summary
+        run:
           make ROUTER="${{ matrix.router }}" BENCHMARKS="${{ matrix.benchmark }}" VERBOSE=1
+      - name: Verify pass (non nxroute-poc)
+        if: matrix.router != 'nxroute-poc'
+        run: |
+          grep -H PASS *.check
+          # Allow following grep to fail if no URL
+          grep -H -e "# of nets with routing errors[. :]\+0" *.check.log || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
+      - name: Verify fail (nxroute-poc)
+        if: matrix.router == 'nxroute-poc'
+        run: |
+          grep -H FAIL *.check
+          # Allow following grep to fail if no URL
+          grep -H -e "# of nets with routing errors[. :]\+[1-9]" -e "# of unrouted nets[. :]\+[1-9]" *.check.log || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java
+++ b/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java
@@ -82,7 +82,7 @@ public class CheckPhysNetlist {
         // Call Vivado's `report_route_status` command on this DCP
         ReportRouteStatusResult rrs = null;
         String reportRouteStatusUrl = System.getenv("REPORT_ROUTE_STATUS_URL");
-        if (reportRouteStatusUrl == null) {
+        if (reportRouteStatusUrl == null || reportRouteStatusUrl.isEmpty()) {
             // Call local Vivado
             if (!FileTools.isVivadoOnPath()) {
                 System.err.println("ERROR: `vivado` not detected on $PATH");

--- a/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java
+++ b/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.zip.Deflater;
 import java.util.zip.ZipOutputStream;
 import java.util.zip.ZipEntry;
 
@@ -99,6 +100,7 @@ public class CheckPhysNetlist {
                 reportRouteStatusUrl += "-zip";
                 try (FileOutputStream fos = new FileOutputStream(uploadFile.toString());
                         ZipOutputStream zos = new ZipOutputStream(fos)) {
+                    zos.setLevel(Deflater.NO_COMPRESSION);
                     zos.putNextEntry(new ZipEntry(outputDcp.toString()));
                     Files.copy(outputDcp, zos);
                     for (String fileName : netlist.getEncryptedCells()) {

--- a/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java
+++ b/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java
@@ -96,6 +96,9 @@ public class CheckPhysNetlist {
             // Upload DCP/ZIP-with-encrpyted-cells to a remote URL
             Path uploadFile = outputDcp;
             if (!netlist.getEncryptedCells().isEmpty()) {
+                // For designs with encrypted cells, create and upload a zip file
+                // containing those encrpyted cells and the *_load.tcl script along
+                // with the DCP 
                 uploadFile = Paths.get(outputDcp.toString() + ".zip");
                 reportRouteStatusUrl += "-zip";
                 try (FileOutputStream fos = new FileOutputStream(uploadFile.toString());


### PR DESCRIPTION
In this contest, Vivado's `report_route_status` is used to check the validity of the routed result. In some cases, it may desirable to acquire this result from a remote server running Vivado. This capability is enabled by this PR when the following two environment variables are set:
* `REPORT_ROUTE_STATUS_URL`
* `REPORT_ROUTE_STATUS_AUTH`

Without these two variables set, the local install of Vivado will be used, as is the case before this PR.

Two ways of using this capability:
1. Running outside of GitHub Actions:
    * `make REPORT_ROUTE_STATUS_URL=<url> REPORT_ROUTE_STATUS_AUTH=<user:pass> ...`
2. Running inside GitHub Actions:
    * Use the [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) facility to set identically named secrets, which will be translated into environment variables by the workflow file.
    * Note: these secrets are not set for the upstream `Xilinx/fpga24_routing_contest` repository.