### PR TITLE
[Doc] Note on RWRoute memory req & VERBOSE flag

### DIFF
--- a/docs/start.md
+++ b/docs/start.md
@@ -85,6 +85,8 @@ Upon calling `make` the default [Makefile](https://github.com/Xilinx/fpga24_rout
 
 The terminal output of RWRoute for each benchmark is available at `<Benchmark>_rwroute.phys.log`
 while the output of `CheckPhysNetlist` can be found at `<Benchmark>_rwroute.check.log`.
+Displaying this output on screen in addition to writing to these logs can be achieved by setting
+the `VERBOSE` flag: `make VERBOSE=1`.
 
 ### Improving On The Baseline
 
@@ -208,6 +210,8 @@ Writing design...
 	Write PhysicalNetlist: 7.7s
 Wall-clock time (sec): 168.94
 ```
+Displaying this output on screen in addition to writing to these logs can be achieved by setting
+the `VERBOSE` flag: `make VERBOSE=1`.
 
 
 ### Reference FPGAIF Physical Netlist Reader/Writer

--- a/docs/start.md
+++ b/docs/start.md
@@ -59,7 +59,7 @@ Upon calling `make` the default [Makefile](https://github.com/Xilinx/fpga24_rout
    Lastly, RapidWright's in-memory representation of the fully-routed design is then written out into a
    new FPGAIF Physical Netlist.
    The wall-clock time of this `PartialRouterPhysNetlist` step is captured using `/usr/bin/time`.
-4. The validity of the routed FPGAIF Physical Netlist is then checked using the [`CheckPhysNetlist`](https://github.com/Xilinx/fpga24_routing_contest/blob/main/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java)
+3. The validity of the routed FPGAIF Physical Netlist is then checked using the [`CheckPhysNetlist`](https://github.com/Xilinx/fpga24_routing_contest/blob/main/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java)
    Java class.
    This class takes the original FPGAIF Logical Netlist, combines it with the routed Physical Netlist
    to generate a Vivado Design Checkpoint (DCP) and loads it in Vivado to undergo `report_route_status`
@@ -67,7 +67,7 @@ Upon calling `make` the default [Makefile](https://github.com/Xilinx/fpga24_rout
    *Note: Currently, this scoring tool does not check that the output netlist's placement and intra-site routing is
    identical to the input netlist's, nor does it compute the critical-path wirelength.
    These capabilities will be added soon.*
-5. Finally, [`compute-score.py`](https://github.com/Xilinx/fpga24_routing_contest/blob/master/compute-score.py) is called to generate output that looks like:
+4. Finally, [`compute-score.py`](https://github.com/Xilinx/fpga24_routing_contest/blob/master/compute-score.py) is called to generate output that looks like:
    ```
    Benchmark                      Wall Clock (sec)
    -----------------------------------------

--- a/docs/start.md
+++ b/docs/start.md
@@ -48,10 +48,18 @@ Upon calling `make` the default [Makefile](https://github.com/Xilinx/fpga24_rout
    This class leverages RapidWright to load the FPGAIF Physical Netlist into RapidWright's in-memory data
    structures, then invokes `PartialRouter` (which is a subclass of `RWRoute` that operates only on
    unrouted nets while preserving all existing routing) to complete routing.
+
+   > **NOTE:**
+   > By default, `PartialRouterPhysNetlist` is configured with 32GB of heap memory for its Java Virtual Machine.
+   > With this configuration, to account for off-heap memory utilization a machine with at least 40GB of free memory is required.
+   > The heap size can be overridden using the following variable `make JVM_HEAP="-Xms14g -Xmx14g"` --
+   > we have determined experimentally that a minimum heap size of 14GB is necessary to complete the 5 initial benchmarks
+   > (at a cost to performance).
+   
    Lastly, RapidWright's in-memory representation of the fully-routed design is then written out into a
    new FPGAIF Physical Netlist.
    The wall-clock time of this `PartialRouterPhysNetlist` step is captured using `/usr/bin/time`.
-3. The validity of the routed FPGAIF Physical Netlist is then checked using the [`CheckPhysNetlist`](https://github.com/Xilinx/fpga24_routing_contest/blob/main/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java)
+4. The validity of the routed FPGAIF Physical Netlist is then checked using the [`CheckPhysNetlist`](https://github.com/Xilinx/fpga24_routing_contest/blob/main/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java)
    Java class.
    This class takes the original FPGAIF Logical Netlist, combines it with the routed Physical Netlist
    to generate a Vivado Design Checkpoint (DCP) and loads it in Vivado to undergo `report_route_status`
@@ -59,7 +67,7 @@ Upon calling `make` the default [Makefile](https://github.com/Xilinx/fpga24_rout
    *Note: Currently, this scoring tool does not check that the output netlist's placement and intra-site routing is
    identical to the input netlist's, nor does it compute the critical-path wirelength.
    These capabilities will be added soon.*
-4. Finally, [`compute-score.py`](https://github.com/Xilinx/fpga24_routing_contest/blob/master/compute-score.py) is called to generate output that looks like:
+5. Finally, [`compute-score.py`](https://github.com/Xilinx/fpga24_routing_contest/blob/master/compute-score.py) is called to generate output that looks like:
    ```
    Benchmark                      Wall Clock (sec)
    -----------------------------------------


### PR DESCRIPTION
Note added to website on RWRoute's default JVM heap size of 32GB, and how that can be reduced:
```
make JVM_HEAP="-Xms14g -Xmx14g"
```

Also a note on how the `VERBOSE` flag can also be set to echo output to the screen as well as logging to file:
```
make VERBOSE=1
```