### PR TITLE
Fix DcpToFPGAIF to add alternate SitePinInst to net

### DIFF
--- a/src/com/xilinx/fpga24_routing_contest/DcpToFPGAIF.java
+++ b/src/com/xilinx/fpga24_routing_contest/DcpToFPGAIF.java
@@ -45,6 +45,7 @@ public class DcpToFPGAIF {
 	    if (altSource == null) {
 	            altSource = DesignTools.getLegalAlternativeOutputPin(net);
 	            if (altSource != null) {
+                            net.addPin(altSource);
                             // Commit this pin to the SiteInst
                             altSource.getSiteInst().addPin(altSource);
                             DesignTools.routeAlternativeOutputSitePin(net, altSource);


### PR DESCRIPTION
In #10, alternate sources were set up before writing out the FPGAIF Physical Netlist.

Unfortunately, I omitted to add the alternate source `SitePinInst` to the net and thus it was not written out into the Physical Netlist. Fixed in this PR.