### PR TITLE
[Actions] Update to Java 21, Python 3.12; cleanup requirements

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -40,12 +40,12 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'gradle'
       - if: matrix.router == 'nxroute-poc'
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
       - name: Download xcvu3p.device (nxroute-poc only)
         if: matrix.router == 'nxroute-poc'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-decorator==4.4.2
-networkx==2.5.1
-pycapnp==1.3.0
+decorator
+networkx
+pycapnp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-networkx
+# Currently, no pycapnp wheels are built for 3.12; build it from source using a fork that forces cython<3
 #pycapnp
 git+https://github.com/eddieh-xlnx/pycapnp.git@install_requires

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+networkx
 # Currently, no pycapnp wheels are built for 3.12; build it from source using a fork that forces cython<3
 #pycapnp
 git+https://github.com/eddieh-xlnx/pycapnp.git@install_requires

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-decorator
 networkx
-pycapnp
+#pycapnp
+git+https://github.com/eddieh-xlnx/pycapnp.git@install_requires


### PR DESCRIPTION
* Unpin specific versions from `requirements.txt`.
* Temporarily build `pycapnp` from source until 3.12 wheel is available.