### PR TITLE
Fix wirelength_analyzer regex warnings

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Verify pass (non nxroute-poc)
         if: matrix.router != 'nxroute-poc'
         run: |
-          grep -H PASS *.check
-          # Allow following grep to fail if no URL
+          # Allow CheckPhysNetlist to fail if no remote access to Vivado
+          grep -H PASS *.check || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
           grep -H -e "# of nets with routing errors[. :]\+0" *.check.log || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
           # Check no multiple sources, no stubs
           ! grep "UserWarning: Found [0-9]\+ sources" *.wirelength

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -54,8 +54,6 @@ jobs:
       - env:
           REPORT_ROUTE_STATUS_URL:      ${{ secrets.REPORT_ROUTE_STATUS_URL }}
           REPORT_ROUTE_STATUS_AUTH:     ${{ secrets.REPORT_ROUTE_STATUS_AUTH }}
-          # With no access to Vivado, assume that CheckPhysNetlist always returns a PASS for all routers except for nxroute-poc
-          CHECK_PHYS_NETLIST_MOCK_PASS: ${{ matrix.router != 'nxroute-poc' && secrets.REPORT_ROUTE_STATUS_URL == '' }}
           # For certain benchmarks, wirelength_analyzer requires more memory than that available in GitHub Actions
           WIRELENGTH_ANALYZER_MOCK_RESULT: ${{ matrix.benchmark == 'koios_dla_like_large' }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,6 @@ fpga-interchange-schema/interchange/capnp/java.capnp:
 %_$(ROUTER).check: %.netlist %_$(ROUTER).phys | compile-java
 	if ./gradlew -DjvmArgs="-Xms6g -Xmx6g" -Dmain=com.xilinx.fpga24_routing_contest.CheckPhysNetlist :run --args='$^' $(call log_and_or_display,$@.log); then \
             echo "PASS" > $@; \
-        elif [[ "$(CHECK_PHYS_NETLIST_MOCK_PASS)" == "true" && -f "$(patsubst %.check,%.dcp,$@)" ]]; then \
-            echo "::warning file=$@::CheckPhysNetlist returned FAIL but CHECK_PHYS_NETLIST_MOCK_PASS is set"; \
-            echo "PASS" > $@; \
         else \
             echo "FAIL" > $@; \
         fi

--- a/docs/score.md
+++ b/docs/score.md
@@ -76,8 +76,8 @@ matched against this `wire1` name and its associated wirelength score.
 | Double Vertical   |`[NS]{2}2_[EW]_BEG[0-7]` |                 3|
 | Quad Horizontal   |`[EW]{2}4_[EW]_BEG[0-7]` |                10|
 | Quad Vertical     |`[NS]{2}4_[EW]_BEG[0-7]` |                 5|
-| Long Horizontal   |`[EW]{2}12_BEG\d`        |                14|
-| Long Vertical     |`[NS]{2}12_BEG\d`        |                12|
+| Long Horizontal   |`[EW]{2}12_BEG[0-7]`     |                14|
+| Long Vertical     |`[NS]{2}12_BEG[0-7]`     |                12|
 | All others (e.g. Bounce) | (no matches above) |               0|
 
 Each of the wirelength scores in the previous table are taken from Table 1 in

--- a/wirelength_analyzer/xcvup_device_data.py
+++ b/wirelength_analyzer/xcvup_device_data.py
@@ -90,49 +90,49 @@ class xcvupDeviceData:
         # et al, link: https://www.rapidwright.io/docs/_downloads/6610b931d8a2e053e69a499d3923077f/FPT19-TimingModel.pdf
         self.pips =  [
             #intra-tile (zero wirelength)
-            (re.compile('LOGIC_OUTS_[LR]\d{1,2}'),                  0),
-            (re.compile('INT_NODE_SDQ_\d{1,2}_INT_OUT[01]'),        0),
-            (re.compile('INT_NODE_IMUX_\d{1,2}_INT_OUT[01]'),       0),
-            (re.compile('INT_INT_SDQ_\d{1,2}_INT_OUT[01]'),         0),
-            (re.compile('INT_NODE_GLOBAL_\d{1,2}_INT_OUT[01]'),     0),
-            (re.compile('IMUX_[EW]\d{1,2}'),                        0),
-            (re.compile('IMUX_(CMT_)?XIPHY\d{1,2}'),                0),
-            (re.compile('CTRL_[EW][0-9]'),                          0),
-            (re.compile('CLE_CLE_[LM]_SITE_0_[A-H](_O|MUX|Q(2)?)'), 0),
-            (re.compile('BYPASS_[EW]\d{1,2}'),                      0),
-            (re.compile('BOUNCE_[EW]_\d{1,2}_FT[01]'),              0),
-            (re.compile('INODE_[EW]_\d{1,2}_FT[01]'),               0),
-            (re.compile('SDQNODE_[EW]_\d{1,2}_FT[01]'),             0),
+            (re.compile(r'LOGIC_OUTS_[LR]\d{1,2}'),                  0),
+            (re.compile(r'INT_NODE_SDQ_\d{1,2}_INT_OUT[01]'),        0),
+            (re.compile(r'INT_NODE_IMUX_\d{1,2}_INT_OUT[01]'),       0),
+            (re.compile(r'INT_INT_SDQ_\d{1,2}_INT_OUT[01]'),         0),
+            (re.compile(r'INT_NODE_GLOBAL_\d{1,2}_INT_OUT[01]'),     0),
+            (re.compile(r'IMUX_[EW]\d{1,2}'),                        0),
+            (re.compile(r'IMUX_(CMT_)?XIPHY\d{1,2}'),                0),
+            (re.compile(r'CTRL_[EW][0-9]'),                          0),
+            (re.compile(r'CLE_CLE_[LM]_SITE_0_[A-H](_O|MUX|Q(2)?)'), 0),
+            (re.compile(r'BYPASS_[EW]\d{1,2}'),                      0),
+            (re.compile(r'BOUNCE_[EW]_\d{1,2}_FT[01]'),              0),
+            (re.compile(r'INODE_[EW]_\d{1,2}_FT[01]'),               0),
+            (re.compile(r'SDQNODE_[EW]_\d{1,2}_FT[01]'),             0),
 
             #single horizontal
-            (re.compile('[EW]{2}1_[EW]_BEG[0-7]'),                  1),
-            (re.compile('WW1_E_7_FT0'),                             1),
+            (re.compile(r'[EW]{2}1_[EW]_BEG[0-7]'),                  1),
+            (re.compile(r'WW1_E_7_FT0'),                             1),
 
             #single vertical
-            (re.compile('[NS]{2}1_[EW]_BEG[0-7]'),                  1),
+            (re.compile(r'[NS]{2}1_[EW]_BEG[0-7]'),                  1),
 
             #double horizontal
-            (re.compile('[EW]{2}2_[EW]_BEG[0-7]'),                  5),
+            (re.compile(r'[EW]{2}2_[EW]_BEG[0-7]'),                  5),
 
             #double vertical
-            (re.compile('[NS]{2}2_[EW]_BEG[0-7]'),                  3),
+            (re.compile(r'[NS]{2}2_[EW]_BEG[0-7]'),                  3),
 
             #quad horizontal
-            (re.compile('[EW]{2}4_[EW]_BEG[0-7]'),                  10),
+            (re.compile(r'[EW]{2}4_[EW]_BEG[0-7]'),                  10),
 
             #quad vertical
-            (re.compile('[NS]{2}4_[EW]_BEG[0-7]'),                  5),
+            (re.compile(r'[NS]{2}4_[EW]_BEG[0-7]'),                  5),
 
             #long horizontal
-            (re.compile('[EW]{2}12_BEG\d'),                         14),
+            (re.compile(r'[EW]{2}12_BEG\d'),                         14),
 
             #long vertical
-            (re.compile('[NS]{2}12_BEG\d'),                         12),
+            (re.compile(r'[NS]{2}12_BEG\d'),                         12),
 
             #ignored (static and global routing resources)
-            (re.compile('VCC_WIRE'),                                0),
-            (re.compile('GND_WIRE[1-3]'),                           0),
-            (re.compile('CLK_LEAF_SITES_\d_CLK_LEAF'),              0),
+            (re.compile(r'VCC_WIRE'),                                0),
+            (re.compile(r'GND_WIRE[1-3]'),                           0),
+            (re.compile(r'CLK_LEAF_SITES_\d_CLK_LEAF'),              0),
         ]
 
     def default_sequential(self, o):

--- a/wirelength_analyzer/xcvup_device_data.py
+++ b/wirelength_analyzer/xcvup_device_data.py
@@ -124,10 +124,10 @@ class xcvupDeviceData:
             (re.compile(r'[NS]{2}4_[EW]_BEG[0-7]'),                  5),
 
             #long horizontal
-            (re.compile(r'[EW]{2}12_BEG\d'),                         14),
+            (re.compile(r'[EW]{2}12_BEG[0-7]'),                      14),
 
             #long vertical
-            (re.compile(r'[NS]{2}12_BEG\d'),                         12),
+            (re.compile(r'[NS]{2}12_BEG[0-7]'),                      12),
 
             #ignored (static and global routing resources)
             (re.compile(r'VCC_WIRE'),                                0),


### PR DESCRIPTION
Also be more precise with long wire regex.
Remove unnecessary `CHECK_PHYS_NETLIST_MOCK_PASS` capability.