### PR TITLE
wirelength_analyzer to check PIP tile before assigning zero WL

### DIFF
--- a/wirelength_analyzer/wa.py
+++ b/wirelength_analyzer/wa.py
@@ -116,7 +116,7 @@ class WirelengthAnalyzer:
         self.placements = {}
         for c in self.phys.placements:
             self.placements[(c.site, c.bel)] = c
-        self.tile_root_name_regex = re.compile(r'(.*)_X\d+Y\d+')
+        self.tile_root_name_regex = re.compile(r'(.+)_X\d+Y\d+')
         self.add_all_nets_to_graph()
 
     def tstart(self):
@@ -256,7 +256,7 @@ class WirelengthAnalyzer:
             is_tile = self.tile_cache.get(tile)
             if is_tile is None:
                 tile_name = sl[tile]
-                is_tile = tile_name.startswith('INT')
+                is_tile = tile_name.startswith('INT_')
                 self.tile_cache[tile] = is_tile
                 if not is_tile and self.tile_root_name_regex.match(tile_name).group(1) not in \
                     ('CLEL_R', 'CLEM', 'CLEM_R', 'BRAM', 'DSP'):

--- a/wirelength_analyzer/wa.py
+++ b/wirelength_analyzer/wa.py
@@ -253,17 +253,17 @@ class WirelengthAnalyzer:
             tile  = seg.pip.tile
             sl = self.phys.strList
 
-            is_tile = self.tile_cache.get(tile)
-            if is_tile is None:
+            is_int_tile = self.tile_cache.get(tile)
+            if is_int_tile is None:
                 tile_name = sl[tile]
-                is_tile = tile_name.startswith('INT_')
-                self.tile_cache[tile] = is_tile
-                if not is_tile and self.tile_root_name_regex.match(tile_name).group(1) not in \
+                is_int_tile = tile_name.startswith('INT_')
+                self.tile_cache[tile] = is_int_tile
+                if not is_int_tile and self.tile_root_name_regex.match(tile_name).group(1) not in \
                     ('CLEL_R', 'CLEM', 'CLEM_R', 'BRAM', 'DSP',
                      'XIPHY_BYTE_L', 'HPIO_L', 'CMT_L'):
                     raise ValueError("Unrecognized tile on PIP: " + tile_name + ',' +  sl[seg.pip.wire0] + ',' + sl[wire1])
 
-            if is_tile:
+            if is_int_tile:
                 wl = self.pip_cache.get(wire1)
                 if wl is not None:
                     return wl

--- a/wirelength_analyzer/wa.py
+++ b/wirelength_analyzer/wa.py
@@ -259,7 +259,8 @@ class WirelengthAnalyzer:
                 is_tile = tile_name.startswith('INT_')
                 self.tile_cache[tile] = is_tile
                 if not is_tile and self.tile_root_name_regex.match(tile_name).group(1) not in \
-                    ('CLEL_R', 'CLEM', 'CLEM_R', 'BRAM', 'DSP'):
+                    ('CLEL_R', 'CLEM', 'CLEM_R', 'BRAM', 'DSP',
+                     'XIPHY_BYTE_L', 'HPIO_L', 'CMT_L'):
                     raise ValueError("Unrecognized tile on PIP: " + tile_name + ',' +  sl[seg.pip.wire0] + ',' + sl[wire1])
 
             if is_tile:


### PR DESCRIPTION
Raise a `ValueError` unless the PIP tile's root name (i.e. the prefix before `_X*Y*`) belongs to:
* `INT*`
* `CLEL_R`
* `CLEM`
* `CLEM_R`
* `BRAM`
* `DSP`
* `XIPHY_BYTE_L` (needed by `ispd16_example2` since it is in-context)
* `HPIO_L` (needed by `ispd16_example2` since it is in-context)
* `CMT_L` (needed by `ispd16_example2` since it is in-context)