### PR TITLE
[WirelengthAnalyzer] Add new connectivity rules

### DIFF
--- a/docs/score.md
+++ b/docs/score.md
@@ -114,7 +114,7 @@ BEL input and output pins for each type of PhysCell.
 |`RAMD32`, `RAMS32`                                                                        | `O5` and `O6` <- `A0` to `A4` | Distributed Memory |
 |`RAMD64E`, `RAMS64E`                                                                      | `O6` <- `A0` to `A5`          | Distributed Memory |
 |`RAMB36E2`, `RAMB18E2`                                                                    | (none) <- (none)              | Block Memory       |
-|`URAM288`                                                                                 | (none) <- (none)              | UltraRAM           |
+|`URAM288`                                                                                 | (none) <- (none)              | UltraRAM Memory    |
 |`MMCME4_ADV`                                                                              | (none) <- (none)              | Clock Manager      |
 |`LUT1`, `LUT2`, `LUT3`, `LUT4`, `LUT5`, `LUT6`                                            | (all) <- (all)                | Look Up Table      |
 |`CARRY8`                                                                                  | [see table CARRY8](#carry8-connectivity) | Fast Carry Logic |
@@ -122,9 +122,9 @@ BEL input and output pins for each type of PhysCell.
 |`IBUFCTRL`                                                                                | (all) <- (all)                | Input Buffer       |
 |`DSP_A_B_DATA`, `DSP_C_DATA`, `DSP_M_DATA`,<br>`DSP_PREADD_DATA`, `DSP_OUTPUT`, `DSP_ALU` | (none) <- (none) [see note](#dsp-cell-connectivity) | DSP Logic |
 |`DSP_MULTIPLIER`, `DSP_PREADD`                                                            | (all) <- (all) [see note](#dsp-cell-connectivity) | DSP Logic |
-|`PCIE40E4`                                                                                | (none) <- (none)              | PCIe hard macro    |
-|`GTYE4_CHANNEL`,`GTYE4_COMMON`                                                            | (none) <- (none)              | gigabit transceiver components |
-|`STARTUPE3`,`ICAPE3`                                                                      | (none) <- (none)              | Device configuration components |
+|`PCIE40E4`                                                                                | (none) <- (none)              | PCIe Hard Macro    |
+|`GTYE4_CHANNEL`,`GTYE4_COMMON`                                                            | (none) <- (none)              | Gigabit Transceiver Components |
+|`STARTUPE3`,`ICAPE3`                                                                      | (none) <- (none)              | Device Configuration Components |
 
 ### CARRY8 Connectivity
 | BEL output pin | BEL input pins                     |

--- a/docs/score.md
+++ b/docs/score.md
@@ -114,6 +114,7 @@ BEL input and output pins for each type of PhysCell.
 |`RAMD32`, `RAMS32`                                                                        | `O5` and `O6` <- `A0` to `A4` | Distributed Memory |
 |`RAMD64E`, `RAMS64E`                                                                      | `O6` <- `A0` to `A5`          | Distributed Memory |
 |`RAMB36E2`, `RAMB18E2`                                                                    | (none) <- (none)              | Block Memory       |
+|`MMCME4_ADV`                                                                              | (none) <- (none)              | Clock Manager      |
 |`LUT1`, `LUT2`, `LUT3`, `LUT4`, `LUT5`, `LUT6`                                            | (all) <- (all)                | Look Up Table      |
 |`CARRY8`                                                                                  | [see table CARRY8](#carry8-connectivity) | Fast Carry Logic |
 |`MUXF7`, `MUXF8`, `MUXF9`                                                                 | (all) <- (all)                | Intrasite Mux      |

--- a/docs/score.md
+++ b/docs/score.md
@@ -114,6 +114,7 @@ BEL input and output pins for each type of PhysCell.
 |`RAMD32`, `RAMS32`                                                                        | `O5` and `O6` <- `A0` to `A4` | Distributed Memory |
 |`RAMD64E`, `RAMS64E`                                                                      | `O6` <- `A0` to `A5`          | Distributed Memory |
 |`RAMB36E2`, `RAMB18E2`                                                                    | (none) <- (none)              | Block Memory       |
+|`URAM288`                                                                                 | (none) <- (none)              | UltraRAM           |
 |`MMCME4_ADV`                                                                              | (none) <- (none)              | Clock Manager      |
 |`LUT1`, `LUT2`, `LUT3`, `LUT4`, `LUT5`, `LUT6`                                            | (all) <- (all)                | Look Up Table      |
 |`CARRY8`                                                                                  | [see table CARRY8](#carry8-connectivity) | Fast Carry Logic |
@@ -121,6 +122,9 @@ BEL input and output pins for each type of PhysCell.
 |`IBUFCTRL`                                                                                | (all) <- (all)                | Input Buffer       |
 |`DSP_A_B_DATA`, `DSP_C_DATA`, `DSP_M_DATA`,<br>`DSP_PREADD_DATA`, `DSP_OUTPUT`, `DSP_ALU` | (none) <- (none) [see note](#dsp-cell-connectivity) | DSP Logic |
 |`DSP_MULTIPLIER`, `DSP_PREADD`                                                            | (all) <- (all) [see note](#dsp-cell-connectivity) | DSP Logic |
+|`PCIE40E4`                                                                                | (none) <- (none)              | PCIe hard macro    |
+|`GTYE4_CHANNEL`,`GTYE4_COMMON`                                                            | (none) <- (none)              | gigabit transceiver components |
+|`STARTUPE3`,`ICAPE3`                                                                      | (none) <- (none)              | Device configuration components |
 
 ### CARRY8 Connectivity
 | BEL output pin | BEL input pins                     |

--- a/wirelength_analyzer/wa.py
+++ b/wirelength_analyzer/wa.py
@@ -110,6 +110,7 @@ class WirelengthAnalyzer:
         self.pips = xcvup.pips
         self.tile_root_name_regex = xcvup.tile_root_name_regex
         self.tile_types = xcvup.tile_types
+        self.global_net_drivers = xcvup.global_net_drivers
         self.pip_cache = {}
         self.tile_cache = {}
         if self.verbosity > 0:
@@ -354,7 +355,7 @@ class WirelengthAnalyzer:
                 # Omit source (BELPins) that don't have any fanout
                 if len(branch.branches) == 0:
                     continue
-                if sl[branch.routeSegment.belPin.bel] in ('BUFCE', 'BUFG_GT', 'BUFG_GT_SYNC'):
+                if sl[branch.routeSegment.belPin.bel] in self.global_net_drivers:
                     # don't analyze global (e.g. clk, rst) nets
                     if self.verbosity > 1:
                         print("Skipping global net:",this_net)

--- a/wirelength_analyzer/xcvup_device_data.py
+++ b/wirelength_analyzer/xcvup_device_data.py
@@ -36,10 +36,10 @@ class xcvupDeviceData:
 
         self.cells = {
             # sequential
-            'FDRE':            self.default_sequential,
-            'FDCE':            self.default_sequential,
-            'FDSE':            self.default_sequential,
-            'FDPE':            self.default_sequential,
+            'FDRE':            self.none_to_none,
+            'FDCE':            self.none_to_none,
+            'FDSE':            self.none_to_none,
+            'FDPE':            self.none_to_none,
 
             'SRL16E':          self.srl16e,
             'SRLC32E':         self.srlc32e,
@@ -50,35 +50,35 @@ class xcvupDeviceData:
             'RAMD64E':         self.ram_64e,
             'RAMS64E':         self.ram_64e,
 
-            'RAMB36E2':        self.default_sequential,
-            'RAMB18E2':        self.default_sequential,
+            'RAMB36E2':        self.none_to_none,
+            'RAMB18E2':        self.none_to_none,
 
-            'MMCME4_ADV':      self.default_sequential,
+            'MMCME4_ADV':      self.none_to_none,
 
-            'URAM288':         self.default_sequential,
+            'URAM288':         self.none_to_none,
 
-            'GTYE4_CHANNEL':   self.default_sequential,
-            'GTYE4_COMMON':    self.default_sequential,
-            'PCIE40E4':        self.default_sequential,
+            'GTYE4_CHANNEL':   self.none_to_none,
+            'GTYE4_COMMON':    self.none_to_none,
+            'PCIE40E4':        self.none_to_none,
 
-            'STARTUPE3':       self.default_sequential,
-            'ICAPE3':          self.default_sequential,
+            'STARTUPE3':       self.none_to_none,
+            'ICAPE3':          self.none_to_none,
 
             # combinatorial
-            'LUT1':            self.default_combinatorial,
-            'LUT2':            self.default_combinatorial,
-            'LUT3':            self.default_combinatorial,
-            'LUT4':            self.default_combinatorial,
-            'LUT5':            self.default_combinatorial,
-            'LUT6':            self.default_combinatorial,
+            'LUT1':            self.all_to_all,
+            'LUT2':            self.all_to_all,
+            'LUT3':            self.all_to_all,
+            'LUT4':            self.all_to_all,
+            'LUT5':            self.all_to_all,
+            'LUT6':            self.all_to_all,
 
             'CARRY8':          self.carry8,
 
-            'MUXF7':           self.default_combinatorial,
-            'MUXF8':           self.default_combinatorial,
-            'MUXF9':           self.default_combinatorial,
+            'MUXF7':           self.all_to_all,
+            'MUXF8':           self.all_to_all,
+            'MUXF9':           self.all_to_all,
 
-            'IBUFCTRL':        self.default_combinatorial,
+            'IBUFCTRL':        self.all_to_all,
 
             # The following cell types are BELs that make up a DSP macro.
             # Such DSPs contains a number of optional pipelining registers,
@@ -86,14 +86,14 @@ class xcvupDeviceData:
             # requires examining the design's corresponding Logical Netlist.
             # For the purpose of the FPGA24 Routing Contest, we optimistically
             # assume that all BELs possessing a CLK pin are fully sequential.
-            'DSP_A_B_DATA':    self.default_sequential,
-            'DSP_C_DATA':      self.default_sequential,
-            'DSP_M_DATA':      self.default_sequential,
-            'DSP_PREADD_DATA': self.default_sequential,
-            'DSP_OUTPUT':      self.default_sequential,
-            'DSP_ALU':         self.default_sequential,
-            'DSP_MULTIPLIER':  self.default_combinatorial,
-            'DSP_PREADD':      self.default_combinatorial,
+            'DSP_A_B_DATA':    self.none_to_none,
+            'DSP_C_DATA':      self.none_to_none,
+            'DSP_M_DATA':      self.none_to_none,
+            'DSP_PREADD_DATA': self.none_to_none,
+            'DSP_OUTPUT':      self.none_to_none,
+            'DSP_ALU':         self.none_to_none,
+            'DSP_MULTIPLIER':  self.all_to_all,
+            'DSP_PREADD':      self.all_to_all,
         }
 
         # pip wirelengths are assigned based on the values provided in Table 1
@@ -160,7 +160,7 @@ class xcvupDeviceData:
             'BUFCE', 'BUFG_GT', 'BUFG_GT_SYNC'
         }
 
-    def default_sequential(self, o):
+    def none_to_none(self, o):
         """
         Default connectivity for combinatorial logic
 
@@ -168,7 +168,7 @@ class xcvupDeviceData:
         """
         return self.empty
 
-    def default_combinatorial(self, o):
+    def all_to_all(self, o):
         """
         Default connectivity for combinatorial logic
 

--- a/wirelength_analyzer/xcvup_device_data.py
+++ b/wirelength_analyzer/xcvup_device_data.py
@@ -53,6 +53,8 @@ class xcvupDeviceData:
             'RAMB36E2':        self.default_sequential,
             'RAMB18E2':        self.default_sequential,
 
+            'MMCME4_ADV':      self.default_sequential,
+
             # combinatorial
             'LUT1':            self.default_combinatorial,
             'LUT2':            self.default_combinatorial,

--- a/wirelength_analyzer/xcvup_device_data.py
+++ b/wirelength_analyzer/xcvup_device_data.py
@@ -147,12 +147,17 @@ class xcvupDeviceData:
             (re.compile(r'CLK_LEAF_SITES_\d_CLK_LEAF'),              0),
         ]
 
-        # recognized tile types and regex to string tile location
+        # recognized tile types and regex to strip tile location
         self.tile_root_name_regex = re.compile(r'(.+)_X\d+Y\d+')
         self.tile_types = {
             'CLEL_R', 'CLEM', 'CLEM_R', 'BRAM', 'DSP', 'XIPHY_BYTE_L',
             'HPIO_L', 'CMT_L', 'URAM_URAM_FT', 'URAM_URAM_DELAY_FT', 'GTY_L',
             'GTY_R'
+        }
+
+        # bels that drive global nets
+        self.global_net_drivers = {
+            'BUFCE', 'BUFG_GT', 'BUFG_GT_SYNC'
         }
 
     def default_sequential(self, o):

--- a/wirelength_analyzer/xcvup_device_data.py
+++ b/wirelength_analyzer/xcvup_device_data.py
@@ -55,6 +55,15 @@ class xcvupDeviceData:
 
             'MMCME4_ADV':      self.default_sequential,
 
+            'URAM288':         self.default_sequential,
+
+            'GTYE4_CHANNEL':   self.default_sequential,
+            'GTYE4_COMMON':    self.default_sequential,
+            'PCIE40E4':        self.default_sequential,
+
+            'STARTUPE3':       self.default_sequential,
+            'ICAPE3':          self.default_sequential,
+
             # combinatorial
             'LUT1':            self.default_combinatorial,
             'LUT2':            self.default_combinatorial,
@@ -99,6 +108,7 @@ class xcvupDeviceData:
             (re.compile(r'INT_NODE_GLOBAL_\d{1,2}_INT_OUT[01]'),     0),
             (re.compile(r'IMUX_[EW]\d{1,2}'),                        0),
             (re.compile(r'IMUX_(CMT_)?XIPHY\d{1,2}'),                0),
+            (re.compile(r'IMUXOUT\d{1,2}'),                          0),
             (re.compile(r'CTRL_[EW][0-9]'),                          0),
             (re.compile(r'CLE_CLE_[LM]_SITE_0_[A-H](_O|MUX|Q(2)?)'), 0),
             (re.compile(r'BYPASS_[EW]\d{1,2}'),                      0),
@@ -136,6 +146,14 @@ class xcvupDeviceData:
             (re.compile(r'GND_WIRE[1-3]'),                           0),
             (re.compile(r'CLK_LEAF_SITES_\d_CLK_LEAF'),              0),
         ]
+
+        # recognized tile types and regex to string tile location
+        self.tile_root_name_regex = re.compile(r'(.+)_X\d+Y\d+')
+        self.tile_types = {
+            'CLEL_R', 'CLEM', 'CLEM_R', 'BRAM', 'DSP', 'XIPHY_BYTE_L',
+            'HPIO_L', 'CMT_L', 'URAM_URAM_FT', 'URAM_URAM_DELAY_FT', 'GTY_L',
+            'GTY_R'
+        }
 
     def default_sequential(self, o):
         """


### PR DESCRIPTION
Add connectivity rules for cells of type:
- `MMCE4_ADV`
- `GTYE4_CHANNEL`
- `GTYE4_COMMON`
- `PCIE40E4`
- `URAM288`
- `STARTUPE3`
- `ICAPE3`

Also add a new PIP wirelength entry, some small refactors, and documentation updates to reflect above changes.