### PR TITLE
[Actions] Downgrade to Java 17

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '17'
           cache: 'gradle'
       - if: matrix.router == 'nxroute-poc'
         uses: actions/setup-python@v4

--- a/.github/workflows/scoring_criteria.yml
+++ b/.github/workflows/scoring_criteria.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-          cache: 'pip'
+          #cache: 'pip'
       - run: |
           cd scoring_formula
           python3 -m unittest test_scoring_formula.py -v


### PR DESCRIPTION
Unfortunately, it looks like even the latest Gradle (8.4 currently) does [not support](https://docs.gradle.org/current/userguide/compatibility.html) running itself (but it does building other applications) using Java 21.

Downgrading to Java 17 to keep things simple.