### PR TITLE
Update requirements.txt to use pre-release pycapnp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ compile-java:
 
 .PHONY: install-python-deps
 install-python-deps:
-	pip install -q -r requirements.txt
+	pip install -q -r requirements.txt --pre
 
 # Download and unpack all benchmarks
 .PHONY: download-benchmarks

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 networkx
-# Currently, no pycapnp wheels are built for 3.12; build it from source using a fork that forces cython<3
-#pycapnp
-git+https://github.com/eddieh-xlnx/pycapnp.git@install_requires
+pycapnp


### PR DESCRIPTION
Since [pycapnp-2.0.0b2](https://pypi.org/project/pycapnp/2.0.0b2/#files) adds pre-compiled wheels for Python 3.12.