### PR TITLE
Fix stubs in corundum_25g

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -82,8 +82,8 @@ jobs:
           grep -H PASS *.check || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
           grep -H -e "# of nets with routing errors[. :]\+0" *.check.log || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
           # Check no multiple sources, no stubs
-          ! grep "UserWarning: Found [0-9]\+ sources" *.wirelength
-          ! grep "UserWarning: Found [0-9]\+ stubs" *.wirelength
+          grep "UserWarning: Found [0-9]\+ sources" *.wirelength && exit 1
+          grep "UserWarning: Found [0-9]\+ stubs" *.wirelength && exit 1
           # Check wirelength was computed
           grep "^Wirelength: [1-9][0-9]*" *.wirelength
       - name: Verify fail (nxroute-poc)
@@ -93,7 +93,7 @@ jobs:
           # Allow following grep to fail if no URL
           grep -H -e "# of nets with routing errors[. :]\+[1-9]" -e "# of unrouted nets[. :]\+[1-9]" *.check.log || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
           # Check no multiple sources, but expect stubs
-          ! grep "UserWarning: Found [0-9]\+ sources" *.wirelength
+          grep "UserWarning: Found [0-9]\+ sources" *.wirelength && exit 1
           grep "UserWarning: Found [0-9]\+ stubs" *.wirelength || ${{ matrix.benchmark == 'koios_dla_like_large' }}
           # Allow wirelength computation to fail since nxroute may not have routed anything or wirelength_analyzer was not run
           grep "^Wirelength: [1-9][0-9]*" *.wirelength || true

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ BENCHMARKS ?= boom_med_pb		\
               ispd16_example2
 
 
-BENCHMARKS_URL = https://github.com/Xilinx/fpga24_routing_contest/releases/latest/download/benchmarks.tar.gz
+BENCHMARKS_URL = https://github.com/eddieh-xlnx/fpga24_routing_contest/releases/download/benchmarks/benchmarks.tar.gz
 
 # Inherit proxy settings from the host if they exist
 HTTPHOST=$(firstword $(subst :, ,$(subst http:,,$(subst /,,$(HTTP_PROXY)))))

--- a/docs/score.md
+++ b/docs/score.md
@@ -119,7 +119,7 @@ BEL input and output pins for each type of PhysCell.
 |`LUT1`, `LUT2`, `LUT3`, `LUT4`, `LUT5`, `LUT6`                                            | (all) <- (all)                | Look Up Table      |
 |`CARRY8`                                                                                  | [see table CARRY8](#carry8-connectivity) | Fast Carry Logic |
 |`MUXF7`, `MUXF8`, `MUXF9`                                                                 | (all) <- (all)                | Intrasite Mux      |
-|`IBUFCTRL`, `INBUF`                                                                       | (all) <- (all)                | Input Buffer       |
+|`IBUFCTRL`, `INBUF`, `OUTBUF`                                                             | (all) <- (all)                | I/O Buffer         |
 |`DSP_A_B_DATA`, `DSP_C_DATA`, `DSP_M_DATA`,<br>`DSP_PREADD_DATA`, `DSP_OUTPUT`, `DSP_ALU` | (none) <- (none) [see note](#dsp-cell-connectivity) | DSP Logic |
 |`DSP_MULTIPLIER`, `DSP_PREADD`                                                            | (all) <- (all) [see note](#dsp-cell-connectivity) | DSP Logic |
 |`PCIE40E4`                                                                                | (none) <- (none)              | PCIe Hard Macro    |

--- a/docs/score.md
+++ b/docs/score.md
@@ -119,7 +119,7 @@ BEL input and output pins for each type of PhysCell.
 |`LUT1`, `LUT2`, `LUT3`, `LUT4`, `LUT5`, `LUT6`                                            | (all) <- (all)                | Look Up Table      |
 |`CARRY8`                                                                                  | [see table CARRY8](#carry8-connectivity) | Fast Carry Logic |
 |`MUXF7`, `MUXF8`, `MUXF9`                                                                 | (all) <- (all)                | Intrasite Mux      |
-|`IBUFCTRL`                                                                                | (all) <- (all)                | Input Buffer       |
+|`IBUFCTRL`, `INBUF`                                                                       | (all) <- (all)                | Input Buffer       |
 |`DSP_A_B_DATA`, `DSP_C_DATA`, `DSP_M_DATA`,<br>`DSP_PREADD_DATA`, `DSP_OUTPUT`, `DSP_ALU` | (none) <- (none) [see note](#dsp-cell-connectivity) | DSP Logic |
 |`DSP_MULTIPLIER`, `DSP_PREADD`                                                            | (all) <- (all) [see note](#dsp-cell-connectivity) | DSP Logic |
 |`PCIE40E4`                                                                                | (none) <- (none)              | PCIe Hard Macro    |
@@ -130,7 +130,7 @@ BEL input and output pins for each type of PhysCell.
 | BEL output pin | BEL input pins                     |
 |------------|----------------------------------------|
 | `O0`       | `CIN`, `S0`                            |
-|`CO0`       | {input pins from `O0`} and `DI0`, `AX` |
+| `CO0`      | {input pins from `O0`} and `DI0`, `AX` |
 | `O1`       | {input pins from `CO0`} and `S1`       |
 | `CO1`      | {input pins from `O1`} and `DI1`, `BX` |
 | `O2`       | {input pins from `C01`} and `S2`       |

--- a/docs/score.md
+++ b/docs/score.md
@@ -119,7 +119,7 @@ BEL input and output pins for each type of PhysCell.
 |`LUT1`, `LUT2`, `LUT3`, `LUT4`, `LUT5`, `LUT6`                                            | (all) <- (all)                | Look Up Table      |
 |`CARRY8`                                                                                  | [see table CARRY8](#carry8-connectivity) | Fast Carry Logic |
 |`MUXF7`, `MUXF8`, `MUXF9`                                                                 | (all) <- (all)                | Intrasite Mux      |
-|`IBUFCTRL`, `INBUF`, `OUTBUF`                                                             | (all) <- (all)                | I/O Buffer         |
+|`IBUFCTRL`, `INBUF`, `OBUFT`                                                              | (all) <- (all)                | I/O Buffer         |
 |`DSP_A_B_DATA`, `DSP_C_DATA`, `DSP_M_DATA`,<br>`DSP_PREADD_DATA`, `DSP_OUTPUT`, `DSP_ALU` | (none) <- (none) [see note](#dsp-cell-connectivity) | DSP Logic |
 |`DSP_MULTIPLIER`, `DSP_PREADD`                                                            | (all) <- (all) [see note](#dsp-cell-connectivity) | DSP Logic |
 |`PCIE40E4`                                                                                | (none) <- (none)              | PCIe Hard Macro    |

--- a/wirelength_analyzer/xcvup_device_data.py
+++ b/wirelength_analyzer/xcvup_device_data.py
@@ -80,7 +80,7 @@ class xcvupDeviceData:
 
             'IBUFCTRL':        self.all_to_all,
             'INBUF':           self.all_to_all,
-            'OUTBUF':          self.all_to_all,
+            'OBUFT':           self.all_to_all,
 
             # The following cell types are BELs that make up a DSP macro.
             # Such DSPs contains a number of optional pipelining registers,

--- a/wirelength_analyzer/xcvup_device_data.py
+++ b/wirelength_analyzer/xcvup_device_data.py
@@ -80,6 +80,7 @@ class xcvupDeviceData:
 
             'IBUFCTRL':        self.all_to_all,
             'INBUF':           self.all_to_all,
+            'OUTBUF':          self.all_to_all,
 
             # The following cell types are BELs that make up a DSP macro.
             # Such DSPs contains a number of optional pipelining registers,

--- a/wirelength_analyzer/xcvup_device_data.py
+++ b/wirelength_analyzer/xcvup_device_data.py
@@ -79,6 +79,7 @@ class xcvupDeviceData:
             'MUXF9':           self.all_to_all,
 
             'IBUFCTRL':        self.all_to_all,
+            'INBUF':           self.all_to_all,
 
             # The following cell types are BELs that make up a DSP macro.
             # Such DSPs contains a number of optional pipelining registers,


### PR DESCRIPTION
* Fixed `corundum_25g` benchmark (that does not have site pins for `inout` ports)
* Add `INBUF` and `OBUFT` as cells that `wirelength_analyzer` recognizes
* Fix GHA workflow to check for no sources/stubs