### PR TITLE
[NXRoute] Allow routethru PIPs for non-CLE/RCLK tiles

### DIFF
--- a/networkx-proof-of-concept-router/nxroute-poc.py
+++ b/networkx-proof-of-concept-router/nxroute-poc.py
@@ -202,7 +202,7 @@ class NxRoutingGraph(nx.DiGraph):
                                         continue
                                 wire2nodeGet = wire2node.get
                                 tileName = s[tile.name]
-                                isCleTile = tileName.startswith('CLE')
+                                isCleOrRclkTile = tileName.startswith('CLE') or tileName.startswith('RCLK')
                                 tileType = tileTypes[tile.type]
                                 tileWires = tileType.wires
                                 # Note that the tileType determines the (superset) of all
@@ -212,9 +212,10 @@ class NxRoutingGraph(nx.DiGraph):
                                 # by the fact that either wire on the PIP does not have a
                                 # corresponding node
                                 for pip in tileType.pips:
-                                        if isCleTile and pip.which() != 'conventional':
+                                        if isCleOrRclkTile and pip.which() != 'conventional':
                                                 # Ignore non-conventional PIPs on CLE tiles
                                                 # (LUT route-thrus that traverse an entire site)
+                                                # and on RCLK tiles (BUFCE routethrus)
                                                 continue
                                         wire0Name = tileWires[pip.wire0]
                                         node0Idx = wire2nodeGet(wire0Name)

--- a/networkx-proof-of-concept-router/nxroute-poc.py
+++ b/networkx-proof-of-concept-router/nxroute-poc.py
@@ -202,6 +202,7 @@ class NxRoutingGraph(nx.DiGraph):
                                         continue
                                 wire2nodeGet = wire2node.get
                                 tileName = s[tile.name]
+                                isCleTile = tileName.startswith('CLE')
                                 tileType = tileTypes[tile.type]
                                 tileWires = tileType.wires
                                 # Note that the tileType determines the (superset) of all
@@ -211,9 +212,9 @@ class NxRoutingGraph(nx.DiGraph):
                                 # by the fact that either wire on the PIP does not have a
                                 # corresponding node
                                 for pip in tileType.pips:
-                                        if pip.which() != 'conventional':
-                                                # Ignore non-conventional PIPs (e.g. LUT route-thrus
-                                                # that traverse an entire site)
+                                        if isCleTile and pip.which() != 'conventional':
+                                                # Ignore non-conventional PIPs on CLE tiles
+                                                # (LUT route-thrus that traverse an entire site)
                                                 continue
                                         wire0Name = tileWires[pip.wire0]
                                         node0Idx = wire2nodeGet(wire0Name)


### PR DESCRIPTION
It turns out that there are some connections (e.g. those driven by an IBUF) require the use of a routethru PIP in order to be routeable. Enable such PIPs, but continue to disable CLE routethrus (representing LUT routethrus, which require a lot more work to determine if it's legal to use) and RCLK routethrus (representing BUFCE routethrus which allows access onto the global routing network).

This scenario does not show up GitHub Actions since NXRoute is restricted to a small window of the device, and so far we don't have the above occurrence in our chosen window.