### PR TITLE
[wirelength_analyzer] Add support for DIFFINBUF

### DIFF
--- a/docs/score.md
+++ b/docs/score.md
@@ -119,7 +119,7 @@ BEL input and output pins for each type of PhysCell.
 |`LUT1`, `LUT2`, `LUT3`, `LUT4`, `LUT5`, `LUT6`                                            | (all) <- (all)                | Look Up Table      |
 |`CARRY8`                                                                                  | [see table CARRY8](#carry8-connectivity) | Fast Carry Logic |
 |`MUXF7`, `MUXF8`, `MUXF9`                                                                 | (all) <- (all)                | Intrasite Mux      |
-|`IBUFCTRL`, `INBUF`, `OBUFT`                                                              | (all) <- (all)                | I/O Buffer         |
+|`IBUFCTRL`, `INBUF`, `OBUFT`, `DIFFINBUF`                                                 | (all) <- (all)                | I/O Buffer         |
 |`DSP_A_B_DATA`, `DSP_C_DATA`, `DSP_M_DATA`,<br>`DSP_PREADD_DATA`, `DSP_OUTPUT`, `DSP_ALU` | (none) <- (none) [see note](#dsp-cell-connectivity) | DSP Logic |
 |`DSP_MULTIPLIER`, `DSP_PREADD`                                                            | (all) <- (all) [see note](#dsp-cell-connectivity) | DSP Logic |
 |`PCIE40E4`                                                                                | (none) <- (none)              | PCIe Hard Macro    |

--- a/wirelength_analyzer/xcvup_device_data.py
+++ b/wirelength_analyzer/xcvup_device_data.py
@@ -81,6 +81,7 @@ class xcvupDeviceData:
             'IBUFCTRL':        self.all_to_all,
             'INBUF':           self.all_to_all,
             'OBUFT':           self.all_to_all,
+            'DIFFINBUF':       self.all_to_all,
 
             # The following cell types are BELs that make up a DSP macro.
             # Such DSPs contains a number of optional pipelining registers,


### PR DESCRIPTION
Primitive used for differential inputs, seen in the `corescore` and `corundum` benchmarks.