### PR TITLE
[RapidWright] Pull in PhysNetlistWriter + RWRoute fixes

### DIFF
--- a/.github/workflows/net_printer.yml
+++ b/.github/workflows/net_printer.yml
@@ -37,9 +37,18 @@ jobs:
           cache: 'pip'
       - run:
           make setup-net_printer download-benchmarks
-      - name: Print static nets
+      - name: Print GND net
         run:
-          python3 net_printer/np.py ${{ matrix.benchmark }}_unrouted.phys GLOBAL_LOGIC0 GLOBAL_LOGIC1
+          python3 net_printer/np.py ${{ matrix.benchmark }}_unrouted.phys GLOBAL_LOGIC0 | tee gnd.physnet
+      - name: Print GND stubs
+        run:
+          sed -n -e '/Stub: 0/,$p' gnd.physnet
+      - name: Print VCC net
+        run:
+          python3 net_printer/np.py ${{ matrix.benchmark }}_unrouted.phys GLOBAL_LOGIC1 | tee vcc.physnet
+      - name: Print VCC stubs
+        run:
+          sed -n -e '/Stub: 0/,$p' vcc.physnet
       - name: Print largest global net (corundum_25g)
         if: matrix.benchmark == 'corundum_25g'
         run:

--- a/.github/workflows/net_printer.yml
+++ b/.github/workflows/net_printer.yml
@@ -41,13 +41,13 @@ jobs:
         run:
           python3 net_printer/np.py ${{ matrix.benchmark }}_unrouted.phys GLOBAL_LOGIC0 | tee gnd.physnet
       - name: Print GND stubs
-        run:
+        run: |
           sed -n -e '/Stub: 0/,$p' gnd.physnet
       - name: Print VCC net
         run:
           python3 net_printer/np.py ${{ matrix.benchmark }}_unrouted.phys GLOBAL_LOGIC1 | tee vcc.physnet
       - name: Print VCC stubs
-        run:
+        run: |
           sed -n -e '/Stub: 0/,$p' vcc.physnet
       - name: Print largest global net (corundum_25g)
         if: matrix.benchmark == 'corundum_25g'

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ BENCHMARKS ?= boom_med_pb		\
               ispd16_example2
 
 
-BENCHMARKS_URL = https://github.com/Xilinx/fpga24_routing_contest/releases/latest/download/benchmarks.tar.gz
+BENCHMARKS_URL = https://github.com/eddieh-xlnx/fpga24_routing_contest/releases/download/benchmarks/benchmarks.tar.gz
 
 # Inherit proxy settings from the host if they exist
 HTTPHOST=$(firstword $(subst :, ,$(subst http:,,$(subst /,,$(HTTP_PROXY)))))


### PR DESCRIPTION
Notably, pulling in:
* https://github.com/Xilinx/RapidWright/pull/928 and
  https://github.com/Xilinx/RapidWright/pull/929
  Fixes various FPGAIF issues with stubs incorrectly appearing on static nets
* https://github.com/Xilinx/RapidWright/pull/927
  Fixes an issue with FPGAIF nets associated with differential IOs
* https://github.com/Xilinx/RapidWright/pull/924
  Fixes an issue when RWRoute's LUT pin swapping feature is enabled
* https://github.com/Xilinx/RapidWright/pull/923
  Fixes an issue where intra-site static routing was being dropped in FPGAIF
* https://github.com/Xilinx/RapidWright/pull/921
  Small bugfix in RWRoute which should slightly improve performance

The fixes in https://github.com/Xilinx/RapidWright/pull/928 & https://github.com/Xilinx/RapidWright/pull/929, https://github.com/Xilinx/RapidWright/pull/927 and https://github.com/Xilinx/RapidWright/pull/923 means that an updated set of benchmarks are needed, so this PR temporarily switches over to a staging URL too for the sake of testing.

Note that contestants will need to re-run the [DcpToFpgaIF](https://github.com/Xilinx/fpga24_routing_contest/pull/10) utility on any private benchmarks they may have in order to enjoy the benefits of these fixes too.