### PR TITLE
[NXRoute] Eliminate route conflicts with pre-routed nets

### DIFF
--- a/.github/workflows/net_printer.yml
+++ b/.github/workflows/net_printer.yml
@@ -37,9 +37,18 @@ jobs:
           cache: 'pip'
       - run:
           make setup-net_printer download-benchmarks
-      - name: Print static nets
+      - name: Print GND net
         run:
-          python3 net_printer/np.py ${{ matrix.benchmark }}_unrouted.phys GLOBAL_LOGIC0 GLOBAL_LOGIC1
+          python3 net_printer/np.py ${{ matrix.benchmark }}_unrouted.phys GLOBAL_LOGIC0 | tee gnd.physnet
+      - name: Print GND stubs
+        run:
+          sed -n -e '/Stub: 0/,$p' gnd.physnet
+      - name: Print VCC net
+        run:
+          python3 net_printer/np.py ${{ matrix.benchmark }}_unrouted.phys GLOBAL_LOGIC1 | tee vcc.physnet
+      - name: Print VCC stubs
+        run:
+          sed -n -e '/Stub: 0/,$p' vcc.physnet
       - name: Print largest global net (corundum_25g)
         if: matrix.benchmark == 'corundum_25g'
         run:

--- a/.github/workflows/net_printer.yml
+++ b/.github/workflows/net_printer.yml
@@ -41,13 +41,13 @@ jobs:
         run:
           python3 net_printer/np.py ${{ matrix.benchmark }}_unrouted.phys GLOBAL_LOGIC0 | tee gnd.physnet
       - name: Print GND stubs
-        run:
+        run: |
           sed -n -e '/Stub: 0/,$p' gnd.physnet
       - name: Print VCC net
         run:
           python3 net_printer/np.py ${{ matrix.benchmark }}_unrouted.phys GLOBAL_LOGIC1 | tee vcc.physnet
       - name: Print VCC stubs
-        run:
+        run: |
           sed -n -e '/Stub: 0/,$p' vcc.physnet
       - name: Print largest global net (corundum_25g)
         if: matrix.benchmark == 'corundum_25g'

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ BENCHMARKS ?= boom_med_pb		\
               ispd16_example2
 
 
-BENCHMARKS_URL = https://github.com/Xilinx/fpga24_routing_contest/releases/latest/download/benchmarks.tar.gz
+BENCHMARKS_URL = https://github.com/eddieh-xlnx/fpga24_routing_contest/releases/download/benchmarks/benchmarks.tar.gz
 
 # Inherit proxy settings from the host if they exist
 HTTPHOST=$(firstword $(subst :, ,$(subst http:,,$(subst /,,$(HTTP_PROXY)))))

--- a/networkx-proof-of-concept-router/nxroute-poc.py
+++ b/networkx-proof-of-concept-router/nxroute-poc.py
@@ -40,6 +40,7 @@ import capnp
 import gzip
 import networkx as nx
 import re
+import resource
 from contextlib import contextmanager
 
 # Tell pycapnp to search for schema files inside the
@@ -605,3 +606,5 @@ if len(sys.argv) != 3:
 with NxRouter.create('xcvu3p.device', sys.argv[1]) as router:
         router.route()
         router.write(sys.argv[2])
+
+print('Peak memory:', resource.getrusage(resource.RUSAGE_SELF).ru_maxrss, 'KB')

--- a/networkx-proof-of-concept-router/nxroute-poc.py
+++ b/networkx-proof-of-concept-router/nxroute-poc.py
@@ -406,6 +406,9 @@ class NxRouter:
                                                         # Tile must be out of bounds
                                                         pass
                                         queue.extend(rb.branches)
+                del self.G.tileType2SiteTypePinName2wire
+                del self.G.site2tileAndTypes
+                del self.G.tile2wire2node
                 tend = time.time()
                 print('\tPrepare site pins: %.1fs' % (tend-tstart))
 

--- a/networkx-proof-of-concept-router/nxroute-poc.py
+++ b/networkx-proof-of-concept-router/nxroute-poc.py
@@ -216,7 +216,8 @@ class NxRoutingGraph(nx.DiGraph):
                                         if isCleOrRclkTile and pip.which() != 'conventional':
                                                 # Ignore non-conventional PIPs on CLE tiles
                                                 # (LUT route-thrus that traverse an entire site)
-                                                # and on RCLK tiles (BUFCE routethrus)
+                                                # and on RCLK tiles (BUFCE route-thrus that access
+                                                # the global routing network)
                                                 continue
                                         wire0Name = tileWires[pip.wire0]
                                         node0Idx = wire2nodeGet(wire0Name)

--- a/networkx-proof-of-concept-router/nxroute-poc.py
+++ b/networkx-proof-of-concept-router/nxroute-poc.py
@@ -15,10 +15,10 @@ baseline for any contest entry, but merely as a reference example.
 Specifically, this code demonstrates how a FPGA Interchange DeviceResources
 file can be parsed to extract the complete routing graph, as well as how an
 Interchange PhysicalNetlist can be parsed to determine the source and sink
-pins/nodes to be routed, and how to insert the routed result back into the
-output PhysicalNetlist.
+pins/nodes to be routed, the routing resources already occupied by pre-routed
+nets, and how to insert the routed result back into the output PhysicalNetlist.
 
-We use the NetworkX package to capture the routing graph, and also call employ
+We use the NetworkX package to capture the routing graph, and also employ
 its shortest-path algorithms to find routing solutions. Since NetworkX is a
 pure Python package, runtime and memory performance is expected to be poor.
 For this reason, by default only a subset of the FPGA routing graph is

--- a/networkx-proof-of-concept-router/nxroute-poc.py
+++ b/networkx-proof-of-concept-router/nxroute-poc.py
@@ -384,6 +384,11 @@ class NxRouter:
 
                                 self.net2pin2node[net.name] = (sourcePin2node,sinkNodes)
                         else:
+                                # This is a non-signal net (i.e. gnd/vcc) or it has no routing
+                                # stubs (meaning it is fully routed). Walk its routing tree
+                                # to identify all used routing resources and remove them from
+                                # the routing graph so that no other nets will conflict.
+
                                 tile2wire2nodeGet = self.G.tile2wire2node.get
                                 queue = list(net.sources)
                                 while queue:
@@ -588,7 +593,7 @@ class NxRouter:
 
 class CachedTextList:
         """Drop-in class for wrapping capnp's 'List<Text>' objects where
-           gotten strings are cached rather than deep copied on each call"""
+           gotten strings are cached rather than deep copied on each lookup"""
         def __init__(self, s):
                 self.s = s
                 self.i = [None] * len(s)

--- a/networkx-proof-of-concept-router/nxroute-poc.py
+++ b/networkx-proof-of-concept-router/nxroute-poc.py
@@ -66,7 +66,7 @@ class NxRoutingGraph(nx.DiGraph):
         MIN_Y = 60
         MAX_Y = 119
 
-        # Entire device (requires ~40GB RAM)
+        # Entire device (requires ~50GB RAM)
         # MIN_X = 0
         # MAX_X = sys.maxsize
         # MIN_Y = 0


### PR DESCRIPTION
From the discussion here: https://github.com/Xilinx/fpga24_routing_contest/discussions/54#discussioncomment-7921770 it may not have been clear how the resources used by pre-routed nets -- clocks, ground, vcc -- can be identified such that they cannot be used by a contestant router.

This is now demonstrated in NXRoute, where resources used by pre-routed nets are removed from the routing graph.

In order to achieve this, some more state needed to be carried about the graph, which may increase memory consumption. On the other hand, I think I identified an optimization which prevents new strings from `pycapnp` being created on every lookup, so there may be a saving too.

On `boom_med_pb`, self-reporting using the added line shows that NXRoute now takes ~45GB for the whole device so I've upped the comment to say ~50GB.