### PR TITLE
[WirelengthAnalyzer] Support U-turns in Laguna tiles

### DIFF
--- a/docs/score.md
+++ b/docs/score.md
@@ -119,7 +119,7 @@ BEL input and output pins for each type of PhysCell.
 |`LUT1`, `LUT2`, `LUT3`, `LUT4`, `LUT5`, `LUT6`                                            | (all) <- (all)                | Look Up Table      |
 |`CARRY8`                                                                                  | [see table CARRY8](#carry8-connectivity) | Fast Carry Logic |
 |`MUXF7`, `MUXF8`, `MUXF9`                                                                 | (all) <- (all)                | Intrasite Mux      |
-|`IBUFCTRL`, `INBUF`, `OBUFT`, `DIFFINBUF`, `IBUFDS_GTE4`                                  | (all) <- (all)                | I/O Buffer         |
+|`IBUFCTRL`, `INBUF`, `OBUFT`, `DIFFINBUF`                                                 | (all) <- (all)                | I/O Buffer         |
 |`DSP_A_B_DATA`, `DSP_C_DATA`, `DSP_M_DATA`,<br>`DSP_PREADD_DATA`, `DSP_OUTPUT`, `DSP_ALU` | (none) <- (none) [see note](#dsp-cell-connectivity) | DSP Logic |
 |`DSP_MULTIPLIER`, `DSP_PREADD`                                                            | (all) <- (all) [see note](#dsp-cell-connectivity) | DSP Logic |
 |`PCIE40E4`                                                                                | (none) <- (none)              | PCIe Hard Macro    |

--- a/docs/score.md
+++ b/docs/score.md
@@ -119,7 +119,7 @@ BEL input and output pins for each type of PhysCell.
 |`LUT1`, `LUT2`, `LUT3`, `LUT4`, `LUT5`, `LUT6`                                            | (all) <- (all)                | Look Up Table      |
 |`CARRY8`                                                                                  | [see table CARRY8](#carry8-connectivity) | Fast Carry Logic |
 |`MUXF7`, `MUXF8`, `MUXF9`                                                                 | (all) <- (all)                | Intrasite Mux      |
-|`IBUFCTRL`, `INBUF`, `OBUFT`, `DIFFINBUF`                                                 | (all) <- (all)                | I/O Buffer         |
+|`IBUFCTRL`, `INBUF`, `OBUFT`, `DIFFINBUF`, `IBUFDS_GTE4`                                  | (all) <- (all)                | I/O Buffer         |
 |`DSP_A_B_DATA`, `DSP_C_DATA`, `DSP_M_DATA`,<br>`DSP_PREADD_DATA`, `DSP_OUTPUT`, `DSP_ALU` | (none) <- (none) [see note](#dsp-cell-connectivity) | DSP Logic |
 |`DSP_MULTIPLIER`, `DSP_PREADD`                                                            | (all) <- (all) [see note](#dsp-cell-connectivity) | DSP Logic |
 |`PCIE40E4`                                                                                | (none) <- (none)              | PCIe Hard Macro    |

--- a/wirelength_analyzer/xcvup_device_data.py
+++ b/wirelength_analyzer/xcvup_device_data.py
@@ -163,7 +163,7 @@ class xcvupDeviceData:
         self.tile_types = {
             'CLEL_R', 'CLEM', 'CLEM_R', 'BRAM', 'DSP', 'XIPHY_BYTE_L',
             'HPIO_L', 'CMT_L', 'URAM_URAM_FT', 'URAM_URAM_DELAY_FT', 'GTY_L',
-            'GTY_R'
+            'GTY_R', 'LAG_LAG'
         }
 
         # bels that drive global nets

--- a/wirelength_analyzer/xcvup_device_data.py
+++ b/wirelength_analyzer/xcvup_device_data.py
@@ -82,7 +82,6 @@ class xcvupDeviceData:
             'INBUF':           self.all_to_all,
             'OBUFT':           self.all_to_all,
             'DIFFINBUF':       self.all_to_all,
-            'IBUFDS_GTE4':     self.all_to_all,
 
             # The following cell types are BELs that make up a DSP macro.
             # Such DSPs contains a number of optional pipelining registers,

--- a/wirelength_analyzer/xcvup_device_data.py
+++ b/wirelength_analyzer/xcvup_device_data.py
@@ -82,6 +82,7 @@ class xcvupDeviceData:
             'INBUF':           self.all_to_all,
             'OBUFT':           self.all_to_all,
             'DIFFINBUF':       self.all_to_all,
+            'IBUFDS_GTE4':     self.all_to_all,
 
             # The following cell types are BELs that make up a DSP macro.
             # Such DSPs contains a number of optional pipelining registers,

--- a/wirelength_analyzer/xcvup_device_data.py
+++ b/wirelength_analyzer/xcvup_device_data.py
@@ -104,6 +104,7 @@ class xcvupDeviceData:
         # et al, link: https://www.rapidwright.io/docs/_downloads/6610b931d8a2e053e69a499d3923077f/FPT19-TimingModel.pdf
         self.pips =  [
             #intra-tile (zero wirelength)
+            # INT tiles
             (re.compile(r'LOGIC_OUTS_[LR]\d{1,2}'),                  0),
             (re.compile(r'INT_NODE_SDQ_\d{1,2}_INT_OUT[01]'),        0),
             (re.compile(r'INT_NODE_IMUX_\d{1,2}_INT_OUT[01]'),       0),
@@ -118,6 +119,13 @@ class xcvupDeviceData:
             (re.compile(r'BOUNCE_[EW]_\d{1,2}_FT[01]'),              0),
             (re.compile(r'INODE_[EW]_\d{1,2}_FT[01]'),               0),
             (re.compile(r'SDQNODE_[EW]_\d{1,2}_FT[01]'),             0),
+            # LAG_LAG tiles
+            (re.compile(r'LAG_MUX_ATOM_\d{1,2}_TXOUT'),              0),
+            (re.compile(r'UBUMP\d{1,2}'),                            0), # In multi-SLR devices, this wire is typically
+                                                                         # used to cross the SLR. Since the xcvu3p is
+                                                                         # a single SLR device, this wire can only be
+                                                                         # used as a 'U-turn' back into the same tile
+            (re.compile(r'RXD\d{1,2}'),                              0),
 
             #single horizontal
             (re.compile(r'[EW]{2}1_[EW]_BEG[0-7]'),                  1),


### PR DESCRIPTION
Since the `xcvu3p` is a single SLR device, no SLR crossings exist. However, one can use Laguna tiles to perform a "U-turn" from an `INT` tile (leaving on the lime green node) back into the `INT tile` (re-entering on the red node, via three pink PIPs):

![image](https://github.com/Xilinx/fpga24_routing_contest/assets/90657806/16596bcf-91c3-4992-9e67-8eafd99bc4b5)

This PR adds support for these three PIPs to the `WirelengthAnalyzer`.
