### PR TITLE
[CheckPhysNetlist] Verify placement & static/clock routing unchanged

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -81,6 +81,8 @@ jobs:
           # Allow CheckPhysNetlist to fail if no remote access to Vivado
           grep -H PASS *.check || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
           grep -H -e "# of nets with routing errors[. :]\+0" *.check.log || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
+          # But CheckPhysNetlist must have no non-PIP differences
+          grep "INFO: No non-PIP differences found between routed and unrouted netlists" *.check.log && exit 1
           # Check no multiple sources, no stubs
           grep "UserWarning: Found [0-9]\+ sources" *.wirelength && exit 1
           grep "UserWarning: Found [0-9]\+ stubs" *.wirelength && exit 1
@@ -90,8 +92,10 @@ jobs:
         if: matrix.router == 'nxroute-poc'
         run: |
           grep -H FAIL *.check
-          # Allow following grep to fail if no URL
+          # Only expect report_route_status output if URL given
           grep -H -e "# of nets with routing errors[. :]\+[1-9]" -e "# of unrouted nets[. :]\+[1-9]" *.check.log || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
+          # But CheckPhysNetlist must have no non-PIP differences
+          grep "INFO: No non-PIP differences found between routed and unrouted netlists" *.check.log && exit 1
           # Check no multiple sources, but expect stubs
           grep "UserWarning: Found [0-9]\+ sources" *.wirelength && exit 1
           grep "UserWarning: Found [0-9]\+ stubs" *.wirelength || ${{ matrix.benchmark == 'koios_dla_like_large' }}

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -82,7 +82,7 @@ jobs:
           grep -H PASS *.check || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
           grep -H -e "# of nets with routing errors[. :]\+0" *.check.log || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
           # But CheckPhysNetlist must have no non-PIP differences
-          grep "INFO: No non-PIP differences found between routed and unrouted netlists" *.check.log && exit 1
+          grep "INFO: No non-PIP differences found between routed and unrouted netlists" *.check.log
           # Check no multiple sources, no stubs
           grep "UserWarning: Found [0-9]\+ sources" *.wirelength && exit 1
           grep "UserWarning: Found [0-9]\+ stubs" *.wirelength && exit 1
@@ -95,7 +95,7 @@ jobs:
           # Only expect report_route_status output if URL given
           grep -H -e "# of nets with routing errors[. :]\+[1-9]" -e "# of unrouted nets[. :]\+[1-9]" *.check.log || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
           # But CheckPhysNetlist must have no non-PIP differences
-          grep "INFO: No non-PIP differences found between routed and unrouted netlists" *.check.log && exit 1
+          grep "INFO: No non-PIP differences found between routed and unrouted netlists" *.check.log
           # Check no multiple sources, but expect stubs
           grep "UserWarning: Found [0-9]\+ sources" *.wirelength && exit 1
           grep "UserWarning: Found [0-9]\+ stubs" *.wirelength || ${{ matrix.benchmark == 'koios_dla_like_large' }}

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -67,8 +67,9 @@ jobs:
       - env:
           REPORT_ROUTE_STATUS_URL:      ${{ secrets.REPORT_ROUTE_STATUS_URL }}
           REPORT_ROUTE_STATUS_AUTH:     ${{ secrets.REPORT_ROUTE_STATUS_AUTH }}
-          # For certain benchmarks, wirelength_analyzer requires more memory than that available in GitHub Actions
+          # For certain benchmarks, wirelength_analyzer/CheckPhysNetlist requires more memory than that available in GitHub Actions
           WIRELENGTH_ANALYZER_MOCK_RESULT: ${{ matrix.benchmark == 'koios_dla_like_large' }}
+          CHECK_PHYS_NETLIST_DIFF_MOCK_RESULT: ${{ matrix.benchmark == 'koios_dla_like_large' }}
           RWROUTE_FORCE_LUT_PIN_SWAP:   ${{ matrix.router == 'rwroute' && matrix.lutpinswap }}
         run: |
           make ROUTER="${{ matrix.router }}" BENCHMARKS="${{ matrix.benchmark }}" VERBOSE=1
@@ -94,9 +95,9 @@ jobs:
           grep -H FAIL *.check
           # Only expect report_route_status output if URL given
           grep -H -e "# of nets with routing errors[. :]\+[1-9]" -e "# of unrouted nets[. :]\+[1-9]" *.check.log || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
-          # But CheckPhysNetlist must have no non-PIP differences
-          grep "INFO: No non-PIP differences found between routed and unrouted netlists" *.check.log
-          # Check no multiple sources, but expect stubs
+          # But CheckPhysNetlist must have no non-PIP differences (except koios because out-of-memory)
+          grep "INFO: No non-PIP differences found between routed and unrouted netlists" *.check.log || ${{ matrix.benchmark == 'koios_dla_like_large' }}
+          # Check no multiple sources, but expect stubs (except koios because out-of-memory)
           grep "UserWarning: Found [0-9]\+ sources" *.wirelength && exit 1
           grep "UserWarning: Found [0-9]\+ stubs" *.wirelength || ${{ matrix.benchmark == 'koios_dla_like_large' }}
           # Allow wirelength computation to fail since nxroute may not have routed anything or wirelength_analyzer was not run

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -82,8 +82,8 @@ jobs:
           # Allow CheckPhysNetlist to fail if no remote access to Vivado
           grep -H PASS *.check || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
           grep -H -e "# of nets with routing errors[. :]\+0" *.check.log || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
-          # But CheckPhysNetlist must have no non-PIP differences
-          grep "INFO: No non-PIP differences found between routed and unrouted netlists" *.check.log
+          # But CheckPhysNetlist must have no differences
+          grep "INFO: No differences found between routed and unrouted netlists" *.check.log
           # Check no multiple sources, no stubs
           grep "UserWarning: Found [0-9]\+ sources" *.wirelength && exit 1
           grep "UserWarning: Found [0-9]\+ stubs" *.wirelength && exit 1
@@ -95,8 +95,8 @@ jobs:
           grep -H FAIL *.check
           # Only expect report_route_status output if URL given
           grep -H -e "# of nets with routing errors[. :]\+[1-9]" -e "# of unrouted nets[. :]\+[1-9]" *.check.log || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
-          # But CheckPhysNetlist must have no non-PIP differences (except koios because out-of-memory)
-          grep "INFO: No non-PIP differences found between routed and unrouted netlists" *.check.log || ${{ matrix.benchmark == 'koios_dla_like_large' }}
+          # But CheckPhysNetlist must have no differences (except koios because out-of-memory)
+          grep "INFO: No differences found between routed and unrouted netlists" *.check.log || ${{ matrix.benchmark == 'koios_dla_like_large' }}
           # Check no multiple sources, but expect stubs (except koios because out-of-memory)
           grep "UserWarning: Found [0-9]\+ sources" *.wirelength && exit 1
           grep "UserWarning: Found [0-9]\+ stubs" *.wirelength || ${{ matrix.benchmark == 'koios_dla_like_large' }}

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ BENCHMARKS ?= boom_med_pb		\
               ispd16_example2
 
 
-BENCHMARKS_URL = https://github.com/Xilinx/fpga24_routing_contest/releases/latest/download/benchmarks.tar.gz
+BENCHMARKS_URL = https://github.com/eddieh-xlnx/fpga24_routing_contest/releases/download/benchmarks/benchmarks.tar.gz
 
 # Inherit proxy settings from the host if they exist
 HTTPHOST=$(firstword $(subst :, ,$(subst http:,,$(subst /,,$(HTTP_PROXY)))))

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ fpga-interchange-schema/interchange/capnp/java.capnp:
 # Gradle is used to invoke the CheckPhysNetlist class' main method with arguments
 # $^ (%.netlist and %_rwroute.phys), and display/redirect all output to $@.log (%_rwroute.check.log).
 # The exit code of Gradle determines if 'PASS' or 'FAIL' is written to $@ (%_rwroute.check)
-%_$(ROUTER).check: %.netlist %_$(ROUTER).phys | compile-java
+%_$(ROUTER).check: %.netlist %_$(ROUTER).phys %_unrouted.phys | compile-java
 	if ./gradlew -DjvmArgs="-Xms6g -Xmx6g" -Dmain=com.xilinx.fpga24_routing_contest.CheckPhysNetlist :run --args='$^' $(call log_and_or_display,$@.log); then \
             echo "PASS" > $@; \
         else \

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ fpga-interchange-schema/interchange/capnp/java.capnp:
 
 %_$(ROUTER).wirelength: %_$(ROUTER).phys | setup-wirelength_analyzer
 	if [[ "$(WIRELENGTH_ANALYZER_MOCK_RESULT)" == "true" ]]; then \
-            echo "::warning file=$@::wirelength_analyzer not run because WIRELENGTH_ANALYZER_MOCK_RESULT is set"; \
+            echo "::warning file=$<::wirelength_analyzer not run because WIRELENGTH_ANALYZER_MOCK_RESULT is set"; \
 	    echo "Wirelength: inf" > $@; \
 	else \
 	    python3 wirelength_analyzer/wa.py $< $(call log_and_or_display,$@); \

--- a/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java
+++ b/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java
@@ -57,6 +57,7 @@ public class CheckPhysNetlist {
 
         // Read the routed and unrouted Physical Netlists
         Design routedDesign = PhysNetlistReader.readPhysNetlist(args[1]);
+        int numDiffs = 0;
         if (System.getenv("CHECK_PHYS_NETLIST_DIFF_MOCK_RESULT").equals("true")) {
             System.out.println("::warning file=" + args[1] + "::CheckPhysNetlist's DesignComparator not run because CHECK_PHYS_NETLIST_DIFF_MOCK_RESULT is set");
         } else {
@@ -64,12 +65,12 @@ public class CheckPhysNetlist {
 
             DesignComparator dc = new DesignComparator();
             dc.setComparePIPs(false);
-            int numDiffs = dc.compareDesigns(unroutedDesign, routedDesign);
-            if (numDiffs == 0) {
-                System.out.println("INFO: No non-PIP differences found between routed and unrouted netlists");
-            } else {
-                System.err.println("ERROR: Detected " + numDiffs + " non-PIP differences between " + args[1] + " and " + args[2]);
-            }
+            numDiffs = dc.compareDesigns(unroutedDesign, routedDesign);
+        }
+        if (numDiffs == 0) {
+            System.out.println("INFO: No non-PIP differences found between routed and unrouted netlists");
+        } else {
+            System.err.println("ERROR: Detected " + numDiffs + " non-PIP differences between " + args[1] + " and " + args[2]);
         }
 
         // Read the Logical Netlist

--- a/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java
+++ b/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java
@@ -64,13 +64,14 @@ public class CheckPhysNetlist {
             Design unroutedDesign = PhysNetlistReader.readPhysNetlist(args[2]);
 
             DesignComparator dc = new DesignComparator();
-            dc.setComparePIPs(false);
+            // Only compare PIPs on static and clock nets
+            dc.setComparePIPs((net) -> net.isStaticNet() || net.isClockNet());
             numDiffs = dc.compareDesigns(unroutedDesign, routedDesign);
         }
         if (numDiffs == 0) {
-            System.out.println("INFO: No non-PIP differences found between routed and unrouted netlists");
+            System.out.println("INFO: No differences found between routed and unrouted netlists");
         } else {
-            System.err.println("ERROR: Detected " + numDiffs + " non-PIP differences between " + args[1] + " and " + args[2]);
+            System.err.println("ERROR: Detected " + numDiffs + " differences between " + args[1] + " and " + args[2]);
         }
 
         // Read the Logical Netlist

--- a/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java
+++ b/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java
@@ -57,16 +57,19 @@ public class CheckPhysNetlist {
 
         // Read the routed and unrouted Physical Netlists
         Design routedDesign = PhysNetlistReader.readPhysNetlist(args[1]);
-        Design unroutedDesign = PhysNetlistReader.readPhysNetlist(args[2]);
-
-        DesignComparator dc = new DesignComparator();
-        dc.setComparePIPs(false);
-        int numDiffs = dc.compareDesigns(unroutedDesign, routedDesign);
-        unroutedDesign = null;
-        if (numDiffs == 0) {
-            System.out.println("INFO: No non-PIP differences found between routed and unrouted netlists");
+        if (System.getenv("CHECK_PHYS_NETLIST_DIFF_MOCK_RESULT").equals("true")) {
+            System.out.println("::warning file=" + args[1] + "::CheckPhysNetlist's DesignComparator not run because CHECK_PHYS_NETLIST_DIFF_MOCK_RESULT is set");
         } else {
-            System.err.println("ERROR: Detected " + numDiffs + " non-PIP differences between " + args[1] + " and " + args[2]);
+            Design unroutedDesign = PhysNetlistReader.readPhysNetlist(args[2]);
+
+            DesignComparator dc = new DesignComparator();
+            dc.setComparePIPs(false);
+            int numDiffs = dc.compareDesigns(unroutedDesign, routedDesign);
+            if (numDiffs == 0) {
+                System.out.println("INFO: No non-PIP differences found between routed and unrouted netlists");
+            } else {
+                System.err.println("ERROR: Detected " + numDiffs + " non-PIP differences between " + args[1] + " and " + args[2]);
+            }
         }
 
         // Read the Logical Netlist


### PR DESCRIPTION
As part of the contest rules, routers are only allowed to modify the inter-site routing (PIPs) of the input Physical Netlist. Verify this is the case by leveraging RapidWright's `DesignComparator` feature: https://github.com/Xilinx/RapidWright/pull/931.