### PR TITLE
Add DiffPhysNetlist utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Utilities:
 * [`net_printer`](https://github.com/Xilinx/fpga24_routing_contest/tree/master/net_printer) -- inspect the routing of nets in a Physical Netlist.
 * [`DcpToFPGAIF`](https://github.com/Xilinx/fpga24_routing_contest/pull/10) -- process a DCP into FPGAIF Logical and Physical Netlists for use with this contest.
 * [`wirelength_analyzer`](https://github.com/Xilinx/fpga24_routing_contest/tree/master/wirelength_analyzer) -- compute a [critical-path wirelength](https://xilinx.github.io/fpga24_routing_contest/score.html#critical-path-wirelength) for a routed FPGAIF Physical Netlist.
+* [`DiffPhysNetlist`](https://github.com/Xilinx/fpga24_routing_contest/pull/66) -- display any placement/intra-site routing differences between two FPGAIF Physical Netlists.

--- a/src/com/xilinx/fpga24_routing_contest/DiffPhysNetlist.java
+++ b/src/com/xilinx/fpga24_routing_contest/DiffPhysNetlist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, Advanced Micro Devices, Inc.  All rights reserved.
+ * Copyright (C) 2024, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Author: Eddie Hung, AMD
  *
@@ -39,7 +39,7 @@ public class DiffPhysNetlist {
         if (numDiffs == 0) {
             System.out.println("INFO: No differences found between routed and unrouted netlists");
         } else {
-            dc.printDiffReportSummary(System.out);
+            dc.printDiffReport(System.out);
         }
 
         System.exit(numDiffs == 0 ? 0 : 1);

--- a/src/com/xilinx/fpga24_routing_contest/DiffPhysNetlist.java
+++ b/src/com/xilinx/fpga24_routing_contest/DiffPhysNetlist.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023, Advanced Micro Devices, Inc.  All rights reserved.
+ *
+ * Author: Eddie Hung, AMD
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+
+package com.xilinx.fpga24_routing_contest;
+
+import com.xilinx.rapidwright.design.Design;
+import com.xilinx.rapidwright.design.compare.DesignComparator;
+import com.xilinx.rapidwright.interchange.PhysNetlistReader;
+
+import java.io.IOException;
+
+public class DiffPhysNetlist {
+    public static void main(String[] args) throws IOException {
+        if (args.length != 2) {
+            System.err.println("USAGE: <routed.phys> <unrouted.phys>");
+            return;
+        }
+
+        // Disable verbose Physical Netlist checks
+        PhysNetlistReader.CHECK_CONSTANT_ROUTING_AND_NET_NAMING = false;
+        PhysNetlistReader.CHECK_AND_CREATE_LOGICAL_CELL_IF_NOT_PRESENT = false;
+        PhysNetlistReader.VALIDATE_MACROS_PLACED_FULLY = false;
+        PhysNetlistReader.CHECK_MACROS_CONSISTENT = false;
+
+        // Read the routed and unrouted Physical Netlists
+        Design routedDesign = PhysNetlistReader.readPhysNetlist(args[0]);
+        Design unroutedDesign = PhysNetlistReader.readPhysNetlist(args[1]);
+
+        DesignComparator dc = new DesignComparator();
+        // Only compare PIPs on static and clock nets
+        dc.setComparePIPs((net) -> net.isStaticNet() || net.isClockNet());
+        int numDiffs = dc.compareDesigns(unroutedDesign, routedDesign);
+        if (numDiffs == 0) {
+            System.out.println("INFO: No differences found between routed and unrouted netlists");
+        } else {
+            dc.printDiffReportSummary(System.out);
+        }
+
+        System.exit(numDiffs == 0 ? 0 : 1);
+    }
+}
+


### PR DESCRIPTION
[Contest rules](https://xilinx.github.io/fpga24_routing_contest/details.html#framework) stipulate that the intra-site routing and placement of the input physical netlist cannot be modified (only inter-site routing/PIPs may be inserted). This is now verified by `CheckPhysNetlist` as of https://github.com/Xilinx/fpga24_routing_contest/pull/64.

This new `DiffPhysNetlist` utility provides a more detailed report for any diffs found, and can be used like so:
```
./gradlew -Dmain=com.xilinx.fpga24_routing_contest.DiffPhysNetlist :run --args="boom_soc_routed.phys boom_soc_unrouted.phys"
```
