### PR TITLE
Add logicnets_jscl and finn_radioml, with fixes

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,4 +1,4 @@
-# Copyright (C) 2023, Advanced Micro Devices, Inc.  All rights reserved.
+# Copyright (C) 2024, Advanced Micro Devices, Inc.  All rights reserved.
 #
 # Author: Eddie Hung, AMD
 #

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -22,10 +22,12 @@ jobs:
           - false
           - true
         benchmark:
+          - logicnets_jscl
           - boom_med_pb
           - vtr_mcml
           - rosetta_fd
           - corundum_25g
+          - finn_radioml
           - vtr_lu64peeng
           - corescore_500
           - corescore_500_pb

--- a/.github/workflows/net_printer.yml
+++ b/.github/workflows/net_printer.yml
@@ -16,10 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         benchmark:
+          - logicnets_jscl
           - boom_med_pb
           - vtr_mcml
           - rosetta_fd
           - corundum_25g
+          - finn_radioml
           - vtr_lu64peeng
           - corescore_500
           - corescore_500_pb
@@ -49,6 +51,10 @@ jobs:
       - name: Print VCC stubs
         run: |
           sed -n -e '/Stub: 0/,$p' vcc.physnet
+      - name: Print global nets (boom_med_pb)
+        if: matrix.benchmark == 'boom_med_pb'
+        run:
+          python3 net_printer/np.py ${{ matrix.benchmark }}_unrouted.phys clock_uncore_clock_IBUF_BUFG system/prci_ctrl_domain/resetSynchronizer/x1_member_allClocks_uncore_reset_catcher/io_sync_reset_chain/output_chain/sync_0_reg_0
       - name: Print largest global net (corundum_25g)
         if: matrix.benchmark == 'corundum_25g'
         run:

--- a/.github/workflows/net_printer.yml
+++ b/.github/workflows/net_printer.yml
@@ -1,4 +1,4 @@
-# Copyright (C) 2023, Advanced Micro Devices, Inc.  All rights reserved.
+# Copyright (C) 2024, Advanced Micro Devices, Inc.  All rights reserved.
 #
 # Author: Eddie Hung, AMD
 #

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ BENCHMARKS ?= logicnets_jscl		\
               ispd16_example2
 
 
-BENCHMARKS_URL = https://github.com/Xilinx/fpga24_routing_contest/releases/latest/download/benchmarks.tar.gz
+#BENCHMARKS_URL = https://github.com/Xilinx/fpga24_routing_contest/releases/latest/download/benchmarks.tar.gz
+BENCHMARKS_URL = https://github.com/eddieh-xlnx/fpga24_routing_contest/releases/download/benchmarks/benchmarks.tar.gz
 
 # Inherit proxy settings from the host if they exist
 HTTPHOST=$(firstword $(subst :, ,$(subst http:,,$(subst /,,$(HTTP_PROXY)))))

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (C) 2023, Advanced Micro Devices, Inc.  All rights reserved.
+# Copyright (C) 2024, Advanced Micro Devices, Inc.  All rights reserved.
 #
 # Author: Eddie Hung, AMD
 #

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,12 @@
 SHELL := /bin/bash -o pipefail
 
 # List of all benchmarks (default to all)
-BENCHMARKS ?= boom_med_pb		\
+BENCHMARKS ?= logicnets_jscl		\
+              boom_med_pb		\
               vtr_mcml			\
               rosetta_fd		\
               corundum_25g		\
+              finn_radioml		\
               vtr_lu64peeng		\
               corescore_500		\
               corescore_500_pb		\

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -7,10 +7,12 @@ table:
 
 |Source Benchmark Suite|Benchmark Name|LUTs|FFs|DSPs|BRAMs|OOC [1]|
 |----------------------|--------------|----|---|----|-----|-------|
+| [LogicNets](https://github.com/Xilinx/logicnets)                                                                        |`jscl` (Jet Substructure Classification L)         |31k |2k  |0   |0  |Y   |
 | [BOOM](https://docs.boom-core.org/en/latest/sections/intro-overview/boom.html)                                          |`med_pb` (MediumBoomConfig with area constraint)   |36k |17k |24  |142|N   |
 | [VTR](https://docs.verilogtorouting.org/en/latest/vtr/benchmarks/#vtr-benchmarks)                                       |`mcml`                                             |43k |15k |105 |142|Y   |
 | [Rosetta](https://github.com/cornell-zhang/rosetta)                                                                     |`fd` (face-detection)                              |46k |39k |72  |62 |Y   |
 | [Corundum](https://github.com/corundum/corundum)                                                                        |`25g` (ADM_PCIE_9V3 25G)                           |73k |96k |0   |221|N   |
+| [FINN](https://github.com/Xilinx/finn)                                                                                  |`radioml`                                          |74k |46k |0   |25 |Y   |
 | [VTR](https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/master/vtr_flow/benchmarks/verilog/LU64PEEng.v) |`lu64peeng`                                        |90k |36k |128 |303|Y   |
 | [CoreScore](https://github.com/olofk/corescore)                                                                         |`500` (500 SERV cores)                             |96k |116k|0   |250|N   |
 | [CoreScore](https://github.com/olofk/corescore)                                                                         |`500_pb` (500 SERV cores with area constraint)     |96k |116k|0   |250|N   |

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -8,3 +8,12 @@ For all enquiries, please contact [eddie.hung@amd.com](mailto:eddie.hung@amd.com
 * Chris Lavin
 * Zak Nafziger
 * Alireza Kaviani
+
+## Acknowledgements
+
+The organizers are grateful to the following people for their help in the development of this contest:
+
+- Nicholas Fraser (AMD)
+- Jakoba Petri-Koenig (AMD)
+- Thomas Preusser (AMD)
+- Shashwat Shrivastava (EPFL)


### PR DESCRIPTION
Make two hidden benchmarks `logicnets_jscl` and `finn_radioml` used for alpha submission evaluation public.

Also updates RapidWright to `2023.2.1` (with a number of improvements relevant and irrelevant to RWRoute) plus two fixes:
- https://github.com/Xilinx/RapidWright/pull/938
- https://github.com/Xilinx/RapidWright/pull/939

that were necessary to ensure the `finn_radioml` result is correct with RWRoute's `--lutPinSwapping` option.