### PR TITLE
[RWRoute] Add --lutRoutethru option (disabled by default)

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -122,8 +122,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ matrix.router }}${{ matrix.router == 'rwroute' && matrix.lutpinswapping && '-lutpinswapping' || ''}}-${{ matrix.benchmark }}
-          name: ${{ matrix.router }}${{ matrix.router == 'rwroute' && matrix.lutroutethru && '-lutroutethru' || ''}}-${{ matrix.benchmark }}
+          name: ${{ matrix.router }}${{ matrix.router == 'rwroute' && matrix.lutpinswapping && '-lutpinswapping' || ''}}${{ matrix.router == 'rwroute' && matrix.lutroutethru && '-lutroutethru' || ''}}-${{ matrix.benchmark }}
           path: |
            *.dcp
            *.phys

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -18,7 +18,10 @@ jobs:
         router:
           - rwroute
           - nxroute-poc
-        lutpinswap:
+        lutpinswapping:
+          - false
+          - true
+        lutroutethru:
           - false
           - true
         benchmark:
@@ -47,7 +50,10 @@ jobs:
             benchmark: ispd16_example2
           # NXRoute does not support LUT pin swapping
           - router: nxroute-poc
-            lutpinswap: true
+            lutpinswapping: true
+          # NXRoute does not support LUT routethrus
+          - router: nxroute-poc
+            lutroutethru: true
     steps:
       - uses: actions/checkout@v3
         with:
@@ -72,7 +78,8 @@ jobs:
           # For certain benchmarks, wirelength_analyzer/CheckPhysNetlist requires more memory than that available in GitHub Actions
           WIRELENGTH_ANALYZER_MOCK_RESULT: ${{ matrix.benchmark == 'koios_dla_like_large' }}
           CHECK_PHYS_NETLIST_DIFF_MOCK_RESULT: ${{ matrix.benchmark == 'koios_dla_like_large' }}
-          RWROUTE_FORCE_LUT_PIN_SWAP:   ${{ matrix.router == 'rwroute' && matrix.lutpinswap }}
+          RWROUTE_FORCE_LUT_PINSWAPPING: ${{ matrix.router == 'rwroute' && matrix.lutpinswapping }}
+          RWROUTE_FORCE_LUT_ROUTETHRU:   ${{ matrix.router == 'rwroute' && matrix.lutroutethru }}
         run: |
           make ROUTER="${{ matrix.router }}" BENCHMARKS="${{ matrix.benchmark }}" VERBOSE=1
       - name: Score summary
@@ -115,7 +122,8 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ matrix.router }}${{ matrix.router == 'rwroute' && matrix.lutpinswap && '-lutpinswap' || ''}}-${{ matrix.benchmark }}
+          name: ${{ matrix.router }}${{ matrix.router == 'rwroute' && matrix.lutpinswapping && '-lutpinswapping' || ''}}-${{ matrix.benchmark }}
+          name: ${{ matrix.router }}${{ matrix.router == 'rwroute' && matrix.lutroutethru && '-lutroutethru' || ''}}-${{ matrix.benchmark }}
           path: |
            *.dcp
            *.phys

--- a/src/com/xilinx/fpga24_routing_contest/PartialRouterPhysNetlist.java
+++ b/src/com/xilinx/fpga24_routing_contest/PartialRouterPhysNetlist.java
@@ -63,14 +63,24 @@ public class PartialRouterPhysNetlist {
         routerArgs.addAll(List.of("--initialPresentCongestionFactor", "0.5"));
         routerArgs.addAll(List.of("--presentCongestionMultiplier", "2"));
         routerArgs.addAll(List.of("--historicalCongestionFactor", "1"));
-        // Optionally, enable LUT pin swapping where all inputs of a LUT are considered
-        // to be equivalent
+
+        // Optionally, allow RWRoute to perform LUT pin swapping such that all LUT input sinks
+        // are considered to be equivalent
         //routerArgs.add("--lutPinSwapping");
 
-        if (System.getenv().getOrDefault("RWROUTE_FORCE_LUT_PIN_SWAP", "false").equals("true")) {
-            // For testing purposes
+        // Optionally, allow RWRoute to consider LUT routethrus, where unused LUT resources
+        // (subject to a number of constraints) can be repurposed as an additional routing
+        // resource
+        //routerArgs.add("--lutRoutethru");
+
+        // Primarily for testing purposes
+        if (System.getenv().getOrDefault("RWROUTE_FORCE_LUT_PINSWAPPING", "false").equals("true")) {
             routerArgs.add("--lutPinSwapping");
-	}
+        }
+        if (System.getenv().getOrDefault("RWROUTE_FORCE_LUT_ROUTETHRU", "false").equals("true")) {
+            routerArgs.add("--lutRoutethru");
+        }
+
         if (routerArgs.contains("--lutPinSwapping")) {
             // Ask RWRoute not to perform any intra-site routing updates to reflect
             // any LUT pin swapping that occurs during routing, to fulfill the


### PR DESCRIPTION
Pulls in https://github.com/Xilinx/RapidWright/pull/932 which added a `--lutRoutethru` option to RWRoute that allows it to consider using unused LUTs as additional routing resources.

As the data in https://github.com/Xilinx/RapidWright/pull/932#issuecomment-1881532199 shows, enabling this option does not unanimously improve the runtime across all benchmarks, and so it is disabled (commented out) by default.
