### PR TITLE
[Makefile] Track user-cpu time (not used for scoring)

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -88,8 +88,9 @@ jobs:
       - name: Verify pass (non nxroute-poc)
         if: matrix.router != 'nxroute-poc'
         run: |
+          set -x
           # Allow CheckPhysNetlist to fail if no remote access to Vivado
-          grep -H PASS *.check || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
+          grep -H PASS *.check || (grep -H FAIL *.check && ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }})
           grep -H -e "# of nets with routing errors[. :]\+0" *.check.log || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
           # But CheckPhysNetlist must have no differences
           grep "INFO: No differences found between routed and unrouted netlists" *.check.log
@@ -101,14 +102,15 @@ jobs:
       - name: Verify fail (nxroute-poc)
         if: matrix.router == 'nxroute-poc'
         run: |
+          set -x
           grep -H FAIL *.check
           # Only expect report_route_status output if URL given
           grep -H -e "# of nets with routing errors[. :]\+[1-9]" -e "# of unrouted nets[. :]\+[1-9]" *.check.log || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
           # But CheckPhysNetlist must have no differences (except koios because out-of-memory)
           grep "INFO: No differences found between routed and unrouted netlists" *.check.log || ${{ matrix.benchmark == 'koios_dla_like_large' }}
-          # Check no multiple sources, but expect stubs (except koios because out-of-memory)
+          # Check no multiple sources, no stubs
           grep "UserWarning: Found [0-9]\+ sources" *.wirelength && exit 1
-          grep "UserWarning: Found [0-9]\+ stubs" *.wirelength || ${{ matrix.benchmark == 'koios_dla_like_large' }}
+          grep "UserWarning: Found [0-9]\+ stubs" *.wirelength && exit 1
           # Allow wirelength computation to fail since nxroute may not have routed anything or wirelength_analyzer was not run
           grep "^Wirelength: [1-9][0-9]*" *.wirelength || true
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -108,9 +108,9 @@ jobs:
           grep -H -e "# of nets with routing errors[. :]\+[1-9]" -e "# of unrouted nets[. :]\+[1-9]" *.check.log || ${{ secrets.REPORT_ROUTE_STATUS_URL == '' }}
           # But CheckPhysNetlist must have no differences (except koios because out-of-memory)
           grep "INFO: No differences found between routed and unrouted netlists" *.check.log || ${{ matrix.benchmark == 'koios_dla_like_large' }}
-          # Check no multiple sources, no stubs
+          # Check no multiple sources, but expect possibility of stubs since nxroute is unlikely to fully route the design
           grep "UserWarning: Found [0-9]\+ sources" *.wirelength && exit 1
-          grep "UserWarning: Found [0-9]\+ stubs" *.wirelength && exit 1
+          grep "UserWarning: Found [0-9]\+ stubs" *.wirelength || true
           # Allow wirelength computation to fail since nxroute may not have routed anything or wirelength_analyzer was not run
           grep "^Wirelength: [1-9][0-9]*" *.wirelength || true
       - uses: actions/upload-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ $(if $(HTTPSHOST),-Dhttps.proxyHost=$(HTTPSHOST) -Dhttps.proxyPort=$(HTTPSPORT),
 # (other supported values: nxroute-poc)
 ROUTER ?= rwroute
 
-# Make /usr/bin/time only print out wall-clock time in seconds
-export TIME=Wall-clock time (sec): %e
+# Make /usr/bin/time only print out wall-clock and user time in seconds
+export TIME="Wall-clock time (sec): %e\nUser-CPU time (sec): %U"
 
 # Existence of the VERBOSE environment variable indicates whether router/
 # checker outputs will be displayed on screen

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ fpga-interchange-schema/interchange/capnp/java.capnp:
 # $^ (%.netlist and %_rwroute.phys), and display/redirect all output to $@.log (%_rwroute.check.log).
 # The exit code of Gradle determines if 'PASS' or 'FAIL' is written to $@ (%_rwroute.check)
 %_$(ROUTER).check: %.netlist %_$(ROUTER).phys %_unrouted.phys $(JAVA_CLASSPATH_TXT)
-	if java -cp $$(cat $(JAVA_CLASSPATH_TXT)) $(JVM_HEAP) com.xilinx.fpga24_routing_contest.CheckPhysNetlist $^ $(call log_and_or_display,$@.log); then \
+	if java -cp $$(cat $(JAVA_CLASSPATH_TXT)) $(JVM_HEAP) com.xilinx.fpga24_routing_contest.CheckPhysNetlist $(wordlist 1,3,$^) $(call log_and_or_display,$@.log); then \
             echo "PASS" > $@; \
         else \
             echo "FAIL" > $@; \

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ run-$(ROUTER): score-$(ROUTER)
 compile-java:
 	_JAVA_OPTIONS="$(JAVA_PROXY)" ./gradlew compileJava
 	_JAVA_OPTIONS="$(JAVA_PROXY)" RapidWright/bin/rapidwright Jython -c "FileTools.ensureDataFilesAreStaticInstallFriendly('xcvu3p')"
-	$(eval CLASSPATH := $(shell ./gradlew -quiet --offline runtimeClasspath):build/classes/java/main)
+	$(eval CLASSPATH := $$(shell ./gradlew -quiet --offline runtimeClasspath):build/classes/java/main)
 
 .PHONY: install-python-deps
 install-python-deps:

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,8 @@ endif
 
 export RAPIDWRIGHT_PATH = $(abspath RapidWright)
 
+GET_CLASSPATH = $$(./gradlew -quiet --offline runtimeClasspath):build/classes/java/main
+
 # Default recipe: route and score all given benchmarks
 .PHONY: run-$(ROUTER)
 run-$(ROUTER): score-$(ROUTER)
@@ -72,7 +74,6 @@ run-$(ROUTER): score-$(ROUTER)
 compile-java:
 	_JAVA_OPTIONS="$(JAVA_PROXY)" ./gradlew compileJava
 	_JAVA_OPTIONS="$(JAVA_PROXY)" RapidWright/bin/rapidwright Jython -c "FileTools.ensureDataFilesAreStaticInstallFriendly('xcvu3p')"
-	$(eval CLASSPATH := $$(shell ./gradlew -quiet --offline runtimeClasspath):build/classes/java/main)
 
 .PHONY: install-python-deps
 install-python-deps:
@@ -97,7 +98,7 @@ fpga-interchange-schema/interchange/capnp/java.capnp:
 # $^ (%.netlist and %_rwroute.phys), and display/redirect all output to $@.log (%_rwroute.check.log).
 # The exit code of Gradle determines if 'PASS' or 'FAIL' is written to $@ (%_rwroute.check)
 %_$(ROUTER).check: %.netlist %_$(ROUTER).phys %_unrouted.phys | compile-java
-	if java -cp $(CLASSPATH) $(JVM_HEAP) com.xilinx.fpga24_routing_contest.CheckPhysNetlist $^ $(call log_and_or_display,$@.log); then \
+	if java -cp $(GET_CLASSPATH) $(JVM_HEAP) com.xilinx.fpga24_routing_contest.CheckPhysNetlist $^ $(call log_and_or_display,$@.log); then \
             echo "PASS" > $@; \
         else \
             echo "FAIL" > $@; \
@@ -140,7 +141,7 @@ distclean: clean
 # Gradle is used to invoke the PartialRouterPhysNetlist class' main method with arguments
 # $< (%_unrouted.phys) and $@ (%_rwroute.phys), and display/redirect all output into %_rwroute.phys.log
 %_rwroute.phys: %_unrouted.phys | compile-java
-	(/usr/bin/time java -cp $(CLASSPATH) $(JVM_HEAP) com.xilinx.fpga24_routing_contest.PartialRouterPhysNetlist $< $@) $(call log_and_or_display,$@.log)
+	(/usr/bin/time java -cp $(GET_CLASSPATH) $(JVM_HEAP) com.xilinx.fpga24_routing_contest.PartialRouterPhysNetlist $< $@) $(call log_and_or_display,$@.log)
 
 
 ## NXROUTE-POC

--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,8 @@ fpga-interchange-schema/interchange/capnp/java.capnp:
 # Gradle is used to invoke the CheckPhysNetlist class' main method with arguments
 # $^ (%.netlist and %_rwroute.phys), and display/redirect all output to $@.log (%_rwroute.check.log).
 # The exit code of Gradle determines if 'PASS' or 'FAIL' is written to $@ (%_rwroute.check)
-%_$(ROUTER).check: %.netlist %_$(ROUTER).phys %_unrouted.phys $(JAVA_CLASSPATH_TXT)
-	if java -cp $$(cat $(JAVA_CLASSPATH_TXT)) $(JVM_HEAP) com.xilinx.fpga24_routing_contest.CheckPhysNetlist $(wordlist 1,3,$^) $(call log_and_or_display,$@.log); then \
+%_$(ROUTER).check: %.netlist %_$(ROUTER).phys %_unrouted.phys | $(JAVA_CLASSPATH_TXT)
+	if java -cp $$(cat $(JAVA_CLASSPATH_TXT)) $(JVM_HEAP) com.xilinx.fpga24_routing_contest.CheckPhysNetlist $^ $(call log_and_or_display,$@.log); then \
             echo "PASS" > $@; \
         else \
             echo "FAIL" > $@; \
@@ -143,7 +143,7 @@ distclean: clean
 # /usr/bin/time is used to measure the wall clock time
 # Gradle is used to invoke the PartialRouterPhysNetlist class' main method with arguments
 # $< (%_unrouted.phys) and $@ (%_rwroute.phys), and display/redirect all output into %_rwroute.phys.log
-%_rwroute.phys: %_unrouted.phys $(JAVA_CLASSPATH_TXT)
+%_rwroute.phys: %_unrouted.phys | $(JAVA_CLASSPATH_TXT)
 	(/usr/bin/time java -cp $$(cat $(JAVA_CLASSPATH_TXT)) $(JVM_HEAP) com.xilinx.fpga24_routing_contest.PartialRouterPhysNetlist $< $@) $(call log_and_or_display,$@.log)
 
 

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ HTTPHOST=$(firstword $(subst :, ,$(subst http:,,$(subst /,,$(HTTP_PROXY)))))
 HTTPPORT=$(lastword $(subst :, ,$(subst http:,,$(subst /,,$(HTTP_PROXY)))))
 HTTPSHOST=$(firstword $(subst :, ,$(subst http:,,$(subst /,,$(HTTPS_PROXY)))))
 HTTPSPORT=$(lastword $(subst :, ,$(subst http:,,$(subst /,,$(HTTPS_PROXY)))))
-JAVA_PROXY=$(if $(HTTPHOST),-Dhttp.proxyHost=$(HTTPHOST) -Dhttp.proxyPort=$(HTTPPORT),) \
-$(if $(HTTPSHOST),-Dhttps.proxyHost=$(HTTPSHOST) -Dhttps.proxyPort=$(HTTPSPORT),)
+JAVA_PROXY=$(if $(HTTPHOST),-Dhttp.proxyHost=$(HTTPHOST) -Dhttp.proxyPort=$(HTTPPORT),)\
+$(if $(HTTPSHOST), -Dhttps.proxyHost=$(HTTPSHOST) -Dhttps.proxyPort=$(HTTPSPORT),)
 
 # Choice of router (default to rwroute)
 # (other supported values: nxroute-poc)

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ run-$(ROUTER): score-$(ROUTER)
 compile-java:
 	_JAVA_OPTIONS="$(JAVA_PROXY)" ./gradlew compileJava
 	_JAVA_OPTIONS="$(JAVA_PROXY)" RapidWright/bin/rapidwright Jython -c "FileTools.ensureDataFilesAreStaticInstallFriendly('xcvu3p')"
-	$(eval CLASSPATH=$(shell ./gradlew -quiet --offline runtimeClasspath):build/classes/java/main)
+	$(eval CLASSPATH := $(shell ./gradlew -quiet --offline runtimeClasspath):build/classes/java/main)
 
 .PHONY: install-python-deps
 install-python-deps:

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,6 @@ endif
 
 export RAPIDWRIGHT_PATH = $(abspath RapidWright)
 
-CLASSPATH = $(shell ./gradlew -quiet --offline runtimeClasspath):build/classes/java/main
-
 # Default recipe: route and score all given benchmarks
 .PHONY: run-$(ROUTER)
 run-$(ROUTER): score-$(ROUTER)
@@ -74,6 +72,7 @@ run-$(ROUTER): score-$(ROUTER)
 compile-java:
 	_JAVA_OPTIONS="$(JAVA_PROXY)" ./gradlew compileJava
 	_JAVA_OPTIONS="$(JAVA_PROXY)" RapidWright/bin/rapidwright Jython -c "FileTools.ensureDataFilesAreStaticInstallFriendly('xcvu3p')"
+	$(eval CLASSPATH=$(shell ./gradlew -quiet --offline runtimeClasspath):build/classes/java/main)
 
 .PHONY: install-python-deps
 install-python-deps:
@@ -97,9 +96,8 @@ fpga-interchange-schema/interchange/capnp/java.capnp:
 # Gradle is used to invoke the CheckPhysNetlist class' main method with arguments
 # $^ (%.netlist and %_rwroute.phys), and display/redirect all output to $@.log (%_rwroute.check.log).
 # The exit code of Gradle determines if 'PASS' or 'FAIL' is written to $@ (%_rwroute.check)
-%_$(ROUTER).check: export CLASSPATH
 %_$(ROUTER).check: %.netlist %_$(ROUTER).phys %_unrouted.phys | compile-java
-	if java $(JVM_HEAP) com.xilinx.fpga24_routing_contest.CheckPhysNetlist $^ $(call log_and_or_display,$@.log); then \
+	if java -cp $(CLASSPATH) $(JVM_HEAP) com.xilinx.fpga24_routing_contest.CheckPhysNetlist $^ $(call log_and_or_display,$@.log); then \
             echo "PASS" > $@; \
         else \
             echo "FAIL" > $@; \
@@ -141,9 +139,8 @@ distclean: clean
 # /usr/bin/time is used to measure the wall clock time
 # Gradle is used to invoke the PartialRouterPhysNetlist class' main method with arguments
 # $< (%_unrouted.phys) and $@ (%_rwroute.phys), and display/redirect all output into %_rwroute.phys.log
-%_rwroute.phys: export CLASSPATH
 %_rwroute.phys: %_unrouted.phys | compile-java
-	(/usr/bin/time java $(JVM_HEAP) com.xilinx.fpga24_routing_contest.PartialRouterPhysNetlist $< $@) $(call log_and_or_display,$@.log)
+	(/usr/bin/time java -cp $(CLASSPATH) $(JVM_HEAP) com.xilinx.fpga24_routing_contest.PartialRouterPhysNetlist $< $@) $(call log_and_or_display,$@.log)
 
 
 ## NXROUTE-POC

--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,13 @@ $(if $(HTTPSHOST), -Dhttps.proxyHost=$(HTTPSHOST) -Dhttps.proxyPort=$(HTTPSPORT)
 ROUTER ?= rwroute
 
 # Make /usr/bin/time only print out wall-clock and user time in seconds
-export TIME=Wall-clock time (sec): %e
-# Note that User-CPU time is for information purposes only (not used for scoring)
-# and is not reported correctly when spawned using Gradle, such as for RWRoute
-export TIME += \nUser-CPU time (sec): %U
+TIME=Wall-clock time (sec): %e
+ifneq ($(ROUTER), rwroute)
+    # Note that User-CPU time is for information purposes only (not used for scoring)
+    # and is not reported correctly when spawned using Gradle, such as for RWRoute
+    TIME += \nUser-CPU time (sec): %U
+endif
+export TIME
 
 # Existence of the VERBOSE environment variable indicates whether router/
 # checker outputs will be displayed on screen

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,10 @@ $(if $(HTTPSHOST),-Dhttps.proxyHost=$(HTTPSHOST) -Dhttps.proxyPort=$(HTTPSPORT),
 ROUTER ?= rwroute
 
 # Make /usr/bin/time only print out wall-clock and user time in seconds
-export TIME="Wall-clock time (sec): %e\nUser-CPU time (sec): %U"
+export TIME=Wall-clock time (sec): %e
+# Note that User-CPU time is for information purposes only (not used for scoring)
+# and is not reported correctly when spawned using Gradle, such as for RWRoute
+export TIME += \nUser-CPU time (sec): %U
 
 # Existence of the VERBOSE environment variable indicates whether router/
 # checker outputs will be displayed on screen

--- a/build.gradle
+++ b/build.gradle
@@ -37,3 +37,8 @@ task run(type: JavaExec) {
     }
 }
 
+task runtimeClasspath {
+    doLast {
+        println configurations.runtimeClasspath.asPath
+    }
+}

--- a/compute-score.py
+++ b/compute-score.py
@@ -35,7 +35,7 @@ def runtime_result(physlogfile):
     """
     reWallClockSeconds = re.compile(r'Wall-clock time \(sec\): ([0-9.]+)')
     with open(physlogfile) as fp:
-        last = fp.readlines()[-1].rstrip()
+        last = fp.readlines()[-2].rstrip()
     m = reWallClockSeconds.match(last)
     if not m:
         return float('inf')


### PR DESCRIPTION
Measure user-CPU time of router just for informational purposes only.

Apparently, Gradle almost always launches itself as a daemon and it was discovered that `/usr/bin/time` cannot capture the user-CPU time of routers spawned from that daemon. Thus, the RWRoute target had to be reworked to invoke `java` directly.