### PR TITLE
Propagate BENCHMARKS in setup-container recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ workdir:
 # (including all setup required for contest infrastructure)
 .PHONY: setup-container
 setup-container: $(ROUTER)_container.sif | workdir
-	apptainer exec $(APPTAINER_RUN_ARGS) $< make setup
+	apptainer exec $(APPTAINER_RUN_ARGS) $< make setup BENCHMARKS="$(BENCHMARKS)"
 
 # Use the <ROUTER>_container.sif Apptainer image to run all benchmarks without network access
 .PHONY: run-container


### PR DESCRIPTION
So that it can be propagated through to the `setup-benchmarks` recipe which only downloads necessary benchmarks.