### PR TITLE
Update/fix Actions; add open-source links/publications

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -39,15 +39,15 @@ jobs:
           - boom_soc
           - ispd16_example2
         exclude:
-          # Insufficient memory on GitHub Actions
-          - router: rwroute
-            benchmark: mlcad_d181_lefttwo3rds
-          - router: rwroute
-            benchmark: koios_dla_like_large
-          - router: rwroute
-            benchmark: boom_soc
-          - router: rwroute
-            benchmark: ispd16_example2
+          ## Insufficient memory on GitHub Actions
+          #- router: rwroute
+          #  benchmark: mlcad_d181_lefttwo3rds
+          #- router: rwroute
+          #  benchmark: koios_dla_like_large
+          #- router: rwroute
+          #  benchmark: boom_soc
+          #- router: rwroute
+          #  benchmark: ispd16_example2
           # NXRoute does not support LUT pin swapping
           - router: nxroute-poc
             lutpinswapping: true

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -39,15 +39,6 @@ jobs:
           - boom_soc
           - ispd16_example2
         exclude:
-          ## Insufficient memory on GitHub Actions
-          #- router: rwroute
-          #  benchmark: mlcad_d181_lefttwo3rds
-          #- router: rwroute
-          #  benchmark: koios_dla_like_large
-          #- router: rwroute
-          #  benchmark: boom_soc
-          #- router: rwroute
-          #  benchmark: ispd16_example2
           # NXRoute does not support LUT pin swapping
           - router: nxroute-poc
             lutpinswapping: true
@@ -76,9 +67,6 @@ jobs:
       - env:
           REPORT_ROUTE_STATUS_URL:      ${{ secrets.REPORT_ROUTE_STATUS_URL }}
           REPORT_ROUTE_STATUS_AUTH:     ${{ secrets.REPORT_ROUTE_STATUS_AUTH }}
-          ## For certain benchmarks, wirelength_analyzer/CheckPhysNetlist requires more memory than that available in GitHub Actions
-          #WIRELENGTH_ANALYZER_MOCK_RESULT: ${{ matrix.benchmark == 'koios_dla_like_large' }}
-          #CHECK_PHYS_NETLIST_DIFF_MOCK_RESULT: ${{ matrix.benchmark == 'koios_dla_like_large' }}
           RWROUTE_FORCE_LUT_PINSWAPPING: ${{ matrix.router == 'rwroute' && matrix.lutpinswapping }}
           RWROUTE_FORCE_LUT_ROUTETHRU:   ${{ matrix.router == 'rwroute' && matrix.lutroutethru }}
         run: |

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -76,9 +76,9 @@ jobs:
       - env:
           REPORT_ROUTE_STATUS_URL:      ${{ secrets.REPORT_ROUTE_STATUS_URL }}
           REPORT_ROUTE_STATUS_AUTH:     ${{ secrets.REPORT_ROUTE_STATUS_AUTH }}
-          # For certain benchmarks, wirelength_analyzer/CheckPhysNetlist requires more memory than that available in GitHub Actions
-          WIRELENGTH_ANALYZER_MOCK_RESULT: ${{ matrix.benchmark == 'koios_dla_like_large' }}
-          CHECK_PHYS_NETLIST_DIFF_MOCK_RESULT: ${{ matrix.benchmark == 'koios_dla_like_large' }}
+          ## For certain benchmarks, wirelength_analyzer/CheckPhysNetlist requires more memory than that available in GitHub Actions
+          #WIRELENGTH_ANALYZER_MOCK_RESULT: ${{ matrix.benchmark == 'koios_dla_like_large' }}
+          #CHECK_PHYS_NETLIST_DIFF_MOCK_RESULT: ${{ matrix.benchmark == 'koios_dla_like_large' }}
           RWROUTE_FORCE_LUT_PINSWAPPING: ${{ matrix.router == 'rwroute' && matrix.lutpinswapping }}
           RWROUTE_FORCE_LUT_ROUTETHRU:   ${{ matrix.router == 'rwroute' && matrix.lutroutethru }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -119,12 +119,7 @@ fpga-interchange-schema/interchange/capnp/java.capnp:
         fi
 
 %_$(ROUTER).wirelength: %_$(ROUTER).phys | setup-wirelength_analyzer
-	if [[ "$(WIRELENGTH_ANALYZER_MOCK_RESULT)" == "true" ]]; then \
-            echo "::warning file=$<::wirelength_analyzer not run because WIRELENGTH_ANALYZER_MOCK_RESULT is set"; \
-	    echo "Wirelength: inf" > $@; \
-	else \
-	    python3 wirelength_analyzer/wa.py $< $(call log_and_or_display,$@); \
-	fi
+	python3 wirelength_analyzer/wa.py $< $(call log_and_or_display,$@); \
 
 .PHONY: score-$(ROUTER)
 score-$(ROUTER): $(foreach b,$(BENCHMARKS),$b_$(ROUTER).wirelength $b_$(ROUTER).check)

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ else
 endif
 
 ifdef GITHUB_ACTIONS
-    # Limit Java heap size inside GitHub Actions to 6G
-    JVM_HEAP = -Xms6g -Xmx6g
+    # Limit Java heap size inside GitHub Actions to 14G
+    JVM_HEAP = -Xms14g -Xmx14g
 else
     # If not specified, limit Java heap size ~32G
     JVM_HEAP ?= -Xms32736m -Xmx32736m

--- a/alpha_submission/rwroute_container.def
+++ b/alpha_submission/rwroute_container.def
@@ -1,5 +1,5 @@
 BootStrap: docker
-From: eclipse-temurin:17 # Base image with Java VM 17 on Ubuntu
+From: eclipse-temurin:17-jre-jammy # Base image with Java VM 17 on Ubuntu 22.04
 
 %post
 	# Install remaining system dependencies

--- a/alpha_submission/rwroute_container.def
+++ b/alpha_submission/rwroute_container.def
@@ -1,5 +1,5 @@
 BootStrap: docker
-From: eclipse-temurin:17-jre-jammy # Base image with Java VM 17 on Ubuntu 22.04
+From: eclipse-temurin:17-jdk-jammy # Base image with Java VM 17 on Ubuntu 22.04
 
 %post
 	# Install remaining system dependencies

--- a/docs/results.md
+++ b/docs/results.md
@@ -18,7 +18,7 @@ For an overview of the reuslts, please see these [slides](fpga24-contest-slides.
 **Advisors:** Shawki Areibi, Gary Grewal
 
 Publication:
-- [High-Definition Routing Congestion Prediction for Large-Scale FPGAs](https://ieeexplore.ieee.org/document/9045178)
+- [A High-Performance Routing Engine for Large-Scale FPGAs](https://doi.ieeecomputersociety.org/10.1109/FPL64840.2024.00017)
 
 | Overview | Video |
 | - | - |

--- a/docs/results.md
+++ b/docs/results.md
@@ -17,6 +17,9 @@ For an overview of the reuslts, please see these [slides](fpga24-contest-slides.
 **Team members:** Dani Maarouf, Timothy Martin, Charlotte Barnes<br>
 **Advisors:** Shawki Areibi, Gary Grewal
 
+Publication:
+- [High-Definition Routing Congestion Prediction for Large-Scale FPGAs](https://ieeexplore.ieee.org/document/9045178)
+
 | Overview | Video |
 | - | - |
 | [![GRoute-Slide](https://github.com/Xilinx/fpga24_routing_contest/assets/90657806/5b279fc6-6c58-43f1-9b51-a0aef72dcf86)](https://github.com/Xilinx/fpga24_routing_contest/assets/90657806/5b279fc6-6c58-43f1-9b51-a0aef72dcf86) | <video src="https://github.com/Xilinx/fpga24_routing_contest/assets/90657806/edbcbd5a-f86b-47fe-ae58-a10c05b15e8a#t=0.5" controls="controls" style="max-width: 662px;"/> |
@@ -25,6 +28,12 @@ For an overview of the reuslts, please see these [slides](fpga24-contest-slides.
 
 **Team members:** Xinshi Zang, Wenhao Lin, Shiju Lin, Qin Luo<br>
 **Advisor:** Evangeline F.Y. Young
+
+Open-source: https://github.com/xszang/parallel-routing ([integrated upstream](https://github.com/Xilinx/fpga24_routing_contest/tree/2nd-cufr))
+
+Publications:
+- [An Open-Source Fast Parallel Routing Approach for Commercial FPGAs](https://github.com/xszang/parallel-routing/blob/main/doc/glsvlsi24-camera-ready.pdf)
+- Potter: A Parallel Overlap-Tolerant Router for UltraScale FPGAs *(to appear)*
 
 | Overview | Video |
 | - | - |
@@ -36,6 +45,9 @@ For an overview of the reuslts, please see these [slides](fpga24-contest-slides.
 **Advisor:** Guojie Luo<sup>*</sup><br>
 *<sup>\*</sup>Peking University, <sup>+</sup>DeePoly Technology Inc.*
 
+Publication:
+- [AceRoute: Adaptive Compute-Efficient FPGA Routing with Pluggable Intra-Connection Bidirectional Exploration](https://xmwei.com/assets/pdf/wei2024aceroute.pdf)
+
 | Overview | Video |
 | - | - |
 | [![AceRoute-Slide](https://github.com/Xilinx/fpga24_routing_contest/assets/90657806/9d7dc7b6-e31d-44df-8e30-90a3f1f19daa)](https://github.com/Xilinx/fpga24_routing_contest/assets/90657806/9d7dc7b6-e31d-44df-8e30-90a3f1f19daa) | <video src="https://github.com/Xilinx/fpga24_routing_contest/assets/90657806/2f1e36da-80cd-4859-8ce8-2bfdaeb3075a#t=0.5" controls="controls" style="max-width: 662px;"/> |
@@ -45,6 +57,8 @@ For an overview of the reuslts, please see these [slides](fpga24-contest-slides.
 **Team members:** Jiarui Wang, Xun Jiang, Chunyuan Zhao<br>
 **Advisor:** Yibo Lin
 
+Open-source: https://github.com/PKU-IDEA/OpenPARF/tree/master/fpga24contest ([integrated upstream](https://github.com/Xilinx/fpga24_routing_contest/tree/4th-cuckoo))
+
 | Overview | Video |
 | - | - |
 | [![TeamCuckoo-Slide](https://github.com/Xilinx/fpga24_routing_contest/assets/90657806/6483ab18-be08-4be3-ad46-8b69a5d13a55)](https://github.com/Xilinx/fpga24_routing_contest/assets/90657806/6483ab18-be08-4be3-ad46-8b69a5d13a55) | <video src="https://github.com/Xilinx/fpga24_routing_contest/assets/90657806/af84a46e-d73a-4b87-be18-9652621f6b5c" controls="controls" style="max-width: 662px;"/> |
@@ -53,6 +67,8 @@ For an overview of the reuslts, please see these [slides](fpga24-contest-slides.
 
 **Team members:** Wenbin Teng, Qianyu Cheng, Zhendong Zheng, Binze Jiang, Yixuan Zhu, Zihan Wang<br>
 **Advisors:** Chao Wang, Teng Wang
+
+Open-source: https://github.com/Reconfigurable-Computing/RapidWright ([integrated upstream](https://github.com/Xilinx/fpga24_routing_contest/tree/5th-hao3))
 
 | Overview | Video |
 | - | - |

--- a/final_submission/rwroute_container.def
+++ b/final_submission/rwroute_container.def
@@ -1,5 +1,5 @@
 BootStrap: docker
-From: eclipse-temurin:17 # Base image with Java VM 17 on Ubuntu
+From: eclipse-temurin:17-jre-jammy # Base image with Java VM 17 on Ubuntu 22.04
 
 %files
 	## Example copy of /dir1 into /opt inside container

--- a/final_submission/rwroute_container.def
+++ b/final_submission/rwroute_container.def
@@ -1,5 +1,5 @@
 BootStrap: docker
-From: eclipse-temurin:17-jre-jammy # Base image with Java VM 17 on Ubuntu 22.04
+From: eclipse-temurin:17-jdk-jammy # Base image with Java VM 17 on Ubuntu 22.04
 
 %files
 	## Example copy of /dir1 into /opt inside container

--- a/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java
+++ b/src/com/xilinx/fpga24_routing_contest/CheckPhysNetlist.java
@@ -57,17 +57,12 @@ public class CheckPhysNetlist {
 
         // Read the routed and unrouted Physical Netlists
         Design routedDesign = PhysNetlistReader.readPhysNetlist(args[1]);
-        int numDiffs = 0;
-        if ("true".equals(System.getenv("CHECK_PHYS_NETLIST_DIFF_MOCK_RESULT"))) {
-            System.out.println("::warning file=" + args[1] + "::CheckPhysNetlist's DesignComparator not run because CHECK_PHYS_NETLIST_DIFF_MOCK_RESULT is set");
-        } else {
-            Design unroutedDesign = PhysNetlistReader.readPhysNetlist(args[2]);
+        Design unroutedDesign = PhysNetlistReader.readPhysNetlist(args[2]);
 
-            DesignComparator dc = new DesignComparator();
-            // Only compare PIPs on static and clock nets
-            dc.setComparePIPs((net) -> net.isStaticNet() || net.isClockNet());
-            numDiffs = dc.compareDesigns(unroutedDesign, routedDesign);
-        }
+        DesignComparator dc = new DesignComparator();
+        // Only compare PIPs on static and clock nets
+        dc.setComparePIPs((net) -> net.isStaticNet() || net.isClockNet());
+        int numDiffs = dc.compareDesigns(unroutedDesign, routedDesign);
         if (numDiffs == 0) {
             System.out.println("INFO: No differences found between routed and unrouted netlists");
         } else {


### PR DESCRIPTION
- Revisit GitHub Actions workflow since GitHub hosted runners now have 4 cores and 16GB of RAM.
  - Now all of the original benchmarks can be run in GHA!
  - Fix Apptainer test too.
- Add links to open-source code from the 3 teams who elected to release
  - Also integrated into this repository under a branch
- Add links to publications made by our winners