### PR TITLE
Update to RapidWright 2024.2.3, Java 21, extend nxroute area

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'gradle'
       - if: matrix.router == 'nxroute-poc'
         uses: actions/setup-python@v5

--- a/.github/workflows/scoring_criteria.yml
+++ b/.github/workflows/scoring_criteria.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: '3.12'
           check-latest: true
-          #cache: 'pip'
+          cache: 'pip'
       - run: |
           cd scoring_formula
           python3 -m unittest test_scoring_formula.py -v

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ compile-java:
 	_JAVA_OPTIONS="$(JAVA_PROXY)" ./gradlew compileJava
 	_JAVA_OPTIONS="$(JAVA_PROXY)" RapidWright/bin/rapidwright Jython -c "FileTools.ensureDataFilesAreStaticInstallFriendly('xcvu3p')"
 install-python-deps:
-	pip install -q -r requirements.txt --pre --user
+	python3 -m pip install -q -r requirements.txt --pre --user
 else
 compile-java install-python-deps:
 	@echo "$@ target skipped since network disabled inside apptainer"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/networkx-proof-of-concept-router/nxroute-poc.py
+++ b/networkx-proof-of-concept-router/nxroute-poc.py
@@ -60,8 +60,8 @@ class NxRoutingGraph(nx.DiGraph):
         to graph node and edge to PIP lookups.
         """
 
-        # Clock Region X1Y1:X4Y3 (requires ~??GB RAM)
-        MIN_X = 21
+        # Clock Region X2Y1:X4Y3 (requires <16GB RAM)
+        MIN_X = 36
         MAX_X = 90
         MIN_Y = 60
         MAX_Y = 239

--- a/networkx-proof-of-concept-router/nxroute-poc.py
+++ b/networkx-proof-of-concept-router/nxroute-poc.py
@@ -60,9 +60,9 @@ class NxRoutingGraph(nx.DiGraph):
         to graph node and edge to PIP lookups.
         """
 
-        # Clock Region X2Y1:X3Y3 (requires ~??GB RAM)
-        MIN_X = 36
-        MAX_X = 71
+        # Clock Region X1Y1:X4Y3 (requires ~??GB RAM)
+        MIN_X = 21
+        MAX_X = 90
         MIN_Y = 60
         MAX_Y = 239
 

--- a/networkx-proof-of-concept-router/nxroute-poc.py
+++ b/networkx-proof-of-concept-router/nxroute-poc.py
@@ -60,11 +60,11 @@ class NxRoutingGraph(nx.DiGraph):
         to graph node and edge to PIP lookups.
         """
 
-        # Clock Region X2Y1 (requires ~5GB RAM)
+        # Clock Region X2Y1:X3Y3 (requires ~??GB RAM)
         MIN_X = 36
-        MAX_X = 56
+        MAX_X = 71
         MIN_Y = 60
-        MAX_Y = 119
+        MAX_Y = 239
 
         # Entire device (requires ~50GB RAM)
         # MIN_X = 0


### PR DESCRIPTION
Update to:
- RapidWright 2024.2.3 + https://github.com/Xilinx/RapidWright/pull/1206 hotfix.
- Gradle 8.14
- Java 21

`nxroute-poc` now tackles routes within 9 clock regions on the xcvu3p device, instead of just 1 previously, taking advantage of the 16 GB RAM now available on GitHub-hosted runners.
Note: limiting design here seems to be `koios_dla_like_large` which peaks at over 15GB.
